### PR TITLE
fix: exclude "system" from resolvedTheme type

### DIFF
--- a/packages/themes/src/core/types.ts
+++ b/packages/themes/src/core/types.ts
@@ -66,7 +66,7 @@ export type ThemeContextValue<Themes extends string = DefaultTheme> = {
 	/** Current theme (may be "system") */
 	theme: Themes | "system" | undefined;
 	/** Resolved theme - never "system" */
-	resolvedTheme: Themes | undefined;
+	resolvedTheme: Exclude<Themes, "system"> | undefined;
 	/** System preference */
 	systemTheme: "light" | "dark" | undefined;
 	/** Forced theme if set */


### PR DESCRIPTION
Fixes #11
`resolvedTheme` is documented as never being `"system"`, but the type `Themes | undefined` leaked `"system"` through `DefaultTheme`. Using `Exclude<Themes, "system">` aligns the type with the runtime behavior.

Before: `resolvedTheme: Themes | undefined` -> `"light" | "dark" | "system" | undefined`
After:  `resolvedTheme: Exclude<Themes, "system"> | undefined` -> `"light" | "dark" | undefined`
