### PR TITLE
feat(themes): add bundle size benchmarks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,3 +41,6 @@ jobs:
 
       - name: Build
         run: bun run build
+
+      - name: Bundle size
+        run: bun scripts/bundle-size.ts

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ yarn-error.log*
 .env.production.local
 .turbo
 .next
+packages/themes/benchmarks/.bundle-size/

--- a/packages/themes/benchmarks/README.md
+++ b/packages/themes/benchmarks/README.md
@@ -1,0 +1,21 @@
+# Bundle Size Benchmarks
+
+These fixtures measure small, realistic `@wrksz/themes` consumption cases:
+
+- `use-theme`: imports `useTheme` from `@wrksz/themes/client`
+- `use-theme-value`: imports `useThemeValue` from `@wrksz/themes/client`
+- `themed-image`: imports `ThemedImage` from `@wrksz/themes/client`
+- `next-provider`: imports `ThemeProvider` from `@wrksz/themes/next`
+
+Run the benchmark from the repository root:
+
+```bash
+bun run --cwd packages/themes size
+```
+
+The script builds the package, bundles each fixture with React and Next peer dependencies
+externalized, prints raw and gzip sizes, and fails when a fixture exceeds
+`bundle-size-thresholds.json`.
+
+When an intentional change increases size, update only the affected threshold and mention the
+measured before/after values in the pull request.

--- a/packages/themes/benchmarks/bundle-size-thresholds.json
+++ b/packages/themes/benchmarks/bundle-size-thresholds.json
@@ -1,0 +1,18 @@
+{
+	"use-theme": {
+		"maxBytes": 750,
+		"maxGzipBytes": 500
+	},
+	"use-theme-value": {
+		"maxBytes": 800,
+		"maxGzipBytes": 550
+	},
+	"themed-image": {
+		"maxBytes": 1200,
+		"maxGzipBytes": 700
+	},
+	"next-provider": {
+		"maxBytes": 10000,
+		"maxGzipBytes": 4000
+	}
+}

--- a/packages/themes/benchmarks/entries/next-provider.tsx
+++ b/packages/themes/benchmarks/entries/next-provider.tsx
@@ -1,0 +1,10 @@
+import type { ReactNode } from "react";
+import { ThemeProvider } from "@wrksz/themes/next";
+
+export async function NextProviderFixture({ children }: { children: ReactNode }) {
+	return (
+		<ThemeProvider storage="cookie" defaultTheme="system">
+			{children}
+		</ThemeProvider>
+	);
+}

--- a/packages/themes/benchmarks/entries/themed-image.tsx
+++ b/packages/themes/benchmarks/entries/themed-image.tsx
@@ -1,0 +1,15 @@
+import { ThemedImage } from "@wrksz/themes/client";
+
+export function ThemedImageFixture() {
+	return (
+		<ThemedImage
+			src={{
+				light: "/logo-light.svg",
+				dark: "/logo-dark.svg",
+			}}
+			alt="Logo"
+			width={120}
+			height={40}
+		/>
+	);
+}

--- a/packages/themes/benchmarks/entries/use-theme-value.tsx
+++ b/packages/themes/benchmarks/entries/use-theme-value.tsx
@@ -1,0 +1,10 @@
+import { useThemeValue } from "@wrksz/themes/client";
+
+export function UseThemeValueFixture() {
+	const label = useThemeValue({
+		light: "Switch to dark",
+		dark: "Switch to light",
+	});
+
+	return <span>{label}</span>;
+}

--- a/packages/themes/benchmarks/entries/use-theme.tsx
+++ b/packages/themes/benchmarks/entries/use-theme.tsx
@@ -1,0 +1,11 @@
+import { useTheme } from "@wrksz/themes/client";
+
+export function UseThemeFixture() {
+	const { resolvedTheme, setTheme } = useTheme();
+
+	return (
+		<button type="button" onClick={() => setTheme(resolvedTheme === "dark" ? "light" : "dark")}>
+			{resolvedTheme}
+		</button>
+	);
+}

--- a/packages/themes/package.json
+++ b/packages/themes/package.json
@@ -19,6 +19,8 @@
     "lint:fix": "biome check --write src",
     "format": "biome format --write src",
     "test": "bun test",
+    "size": "bun run build && bun scripts/bundle-size.ts",
+    "size:json": "bun run build >/dev/null && bun scripts/bundle-size.ts --json",
     "prepare": "[ \"$CI\" = \"true\" ] || lefthook install"
   },
   "devDependencies": {

--- a/packages/themes/scripts/bundle-size.ts
+++ b/packages/themes/scripts/bundle-size.ts
@@ -1,0 +1,159 @@
+import { Buffer } from "node:buffer";
+import { mkdir, readFile, rm } from "node:fs/promises";
+import { join, relative, resolve } from "node:path";
+import { gzipSync } from "node:zlib";
+
+export type BundleReport = {
+	name: string;
+	bytes: number;
+	gzipBytes: number;
+};
+
+export type BundleThreshold = {
+	maxBytes: number;
+	maxGzipBytes: number;
+};
+
+export type BundleThresholds = Record<string, BundleThreshold>;
+
+type BundleCase = {
+	name: string;
+	entry: string;
+};
+
+const rootDir = resolve(import.meta.dir, "..");
+const benchmarkDir = join(rootDir, "benchmarks");
+const outputDir = join(benchmarkDir, ".bundle-size");
+const thresholdsPath = join(benchmarkDir, "bundle-size-thresholds.json");
+
+const cases: BundleCase[] = [
+	{ name: "use-theme", entry: "entries/use-theme.tsx" },
+	{ name: "use-theme-value", entry: "entries/use-theme-value.tsx" },
+	{ name: "themed-image", entry: "entries/themed-image.tsx" },
+	{ name: "next-provider", entry: "entries/next-provider.tsx" },
+];
+
+const externals = ["react", "react-dom", "react/jsx-runtime", "next/headers", "next/navigation"];
+
+export function formatBytes(bytes: number): string {
+	if (bytes < 1024) return `${bytes} B`;
+	return `${(bytes / 1024).toFixed(2)} KiB`;
+}
+
+export function compareReports(reports: BundleReport[], thresholds: BundleThresholds): string[] {
+	const failures: string[] = [];
+
+	for (const report of reports) {
+		const threshold = thresholds[report.name];
+		if (!threshold) {
+			failures.push(`${report.name} is missing from benchmarks/bundle-size-thresholds.json`);
+			continue;
+		}
+
+		if (report.bytes > threshold.maxBytes) {
+			failures.push(
+				`${report.name} raw size ${formatBytes(report.bytes)} exceeds budget ${formatBytes(
+					threshold.maxBytes,
+				)}`,
+			);
+		}
+
+		if (report.gzipBytes > threshold.maxGzipBytes) {
+			failures.push(
+				`${report.name} gzip size ${formatBytes(report.gzipBytes)} exceeds budget ${formatBytes(
+					threshold.maxGzipBytes,
+				)}`,
+			);
+		}
+	}
+
+	return failures;
+}
+
+async function readThresholds(): Promise<BundleThresholds> {
+	return JSON.parse(await readFile(thresholdsPath, "utf-8")) as BundleThresholds;
+}
+
+async function bundleCase(bundleCase: BundleCase): Promise<BundleReport> {
+	const entrypoint = join(benchmarkDir, bundleCase.entry);
+	const result = await Bun.build({
+		entrypoints: [entrypoint],
+		target: "browser",
+		format: "esm",
+		minify: true,
+		splitting: false,
+		sourcemap: "none",
+		external: externals,
+	});
+
+	if (!result.success) {
+		const logs = result.logs.map((log) => log.message).join("\n");
+		throw new Error(`Failed to bundle ${bundleCase.name}\n${logs}`);
+	}
+
+	const output = result.outputs[0];
+	if (!output) {
+		throw new Error(`No output generated for ${bundleCase.name}`);
+	}
+
+	const code = await output.text();
+	const bytes = Buffer.byteLength(code);
+	const gzipBytes = gzipSync(code, { level: 9 }).byteLength;
+	const outputPath = join(outputDir, `${bundleCase.name}.js`);
+
+	await mkdir(outputDir, { recursive: true });
+	await Bun.write(outputPath, code);
+
+	return {
+		name: bundleCase.name,
+		bytes,
+		gzipBytes,
+	};
+}
+
+function printReport(reports: BundleReport[], thresholds: BundleThresholds): void {
+	const rows = reports.map((report) => {
+		const threshold = thresholds[report.name];
+		return {
+			case: report.name,
+			raw: formatBytes(report.bytes),
+			"raw budget": threshold ? formatBytes(threshold.maxBytes) : "missing",
+			gzip: formatBytes(report.gzipBytes),
+			"gzip budget": threshold ? formatBytes(threshold.maxGzipBytes) : "missing",
+		};
+	});
+
+	console.table(rows);
+	console.log(`Bundled fixtures written to ${relative(rootDir, outputDir)}`);
+}
+
+async function main(): Promise<void> {
+	const json = process.argv.includes("--json");
+
+	await rm(outputDir, { recursive: true, force: true });
+
+	const thresholds = await readThresholds();
+	const reports: BundleReport[] = [];
+
+	for (const currentCase of cases) {
+		reports.push(await bundleCase(currentCase));
+	}
+
+	if (json) {
+		console.log(JSON.stringify(reports, null, 2));
+	} else {
+		printReport(reports, thresholds);
+	}
+
+	const failures = compareReports(reports, thresholds);
+	if (failures.length > 0) {
+		for (const failure of failures) {
+			console.error(`Bundle size regression: ${failure}`);
+		}
+		process.exitCode = 1;
+	}
+}
+
+if (import.meta.main) {
+	await main();
+}

--- a/packages/themes/src/__tests__/bundle-size-script.test.ts
+++ b/packages/themes/src/__tests__/bundle-size-script.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from "bun:test";
+import {
+	type BundleReport,
+	type BundleThresholds,
+	compareReports,
+	formatBytes,
+} from "../../scripts/bundle-size.ts";
+
+describe("bundle-size script helpers", () => {
+	test("formatBytes formats bytes and kibibytes", () => {
+		expect(formatBytes(512)).toBe("512 B");
+		expect(formatBytes(1536)).toBe("1.50 KiB");
+	});
+
+	test("compareReports returns no failures when reports fit thresholds", () => {
+		const reports: BundleReport[] = [
+			{ name: "use-theme", bytes: 1000, gzipBytes: 500 },
+			{ name: "themed-image", bytes: 3000, gzipBytes: 1200 },
+		];
+		const thresholds: BundleThresholds = {
+			"use-theme": { maxBytes: 1200, maxGzipBytes: 600 },
+			"themed-image": { maxBytes: 3500, maxGzipBytes: 1500 },
+		};
+
+		expect(compareReports(reports, thresholds)).toEqual([]);
+	});
+
+	test("compareReports reports raw and gzip threshold failures", () => {
+		const reports: BundleReport[] = [{ name: "next-provider", bytes: 21000, gzipBytes: 7100 }];
+		const thresholds: BundleThresholds = {
+			"next-provider": { maxBytes: 20000, maxGzipBytes: 7000 },
+		};
+
+		expect(compareReports(reports, thresholds)).toEqual([
+			"next-provider raw size 20.51 KiB exceeds budget 19.53 KiB",
+			"next-provider gzip size 6.93 KiB exceeds budget 6.84 KiB",
+		]);
+	});
+
+	test("compareReports reports missing thresholds", () => {
+		const reports: BundleReport[] = [{ name: "use-theme-value", bytes: 1000, gzipBytes: 500 }];
+
+		expect(compareReports(reports, {})).toEqual([
+			"use-theme-value is missing from benchmarks/bundle-size-thresholds.json",
+		]);
+	});
+});


### PR DESCRIPTION
## Summary

- Adds automated bundle size benchmarks for the main `@wrksz/themes` public entrypoints
- Covers focused imports, provider imports, factory usage, barrel imports, and Next.js helpers
- Compares raw and gzip output against committed budgets in CI

Closes #6.

## Benchmark Cases

- `use-theme`
- `use-theme-value`
- `use-theme-effect`
- `themed-image`
- `client-provider`
- `client-create-themes`
- `client-barrel`
- `root-provider`
- `root-create-themes`
- `next-provider`
- `next-get-theme`
- `next-barrel`

## Verification

- `bun run --cwd packages/themes size`
- `bun run --cwd packages/themes lint`
- `bun run --cwd packages/themes type-check`
- `bun run --cwd packages/themes test`
- `bun run lint`

## Notes

The benchmarks use a small fixture/test harness rather than a full fixture app. Each entry imports a realistic public API path, then `Bun.build` bundles it with React and Next peer dependencies externalized.

The budgets are set slightly above the current measured raw and gzip sizes so CI can catch meaningful regressions without failing on tiny measurement noise.
