### PR TITLE
Set up Cursor Cloud dev environment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,31 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This is a Bun-managed TypeScript monorepo (Bun workspaces). Two workspaces:
+
+- `packages/themes` — `@wrksz/themes`, the shippable theme-management library (this is the product).
+- `apps/docs` — `theme-docs`, the Next.js + Fumadocs documentation site that consumes the library. Run it to manually exercise the library end to end.
+
+There is no backend, database, or external service. Bun is the package manager (CI pins `1.3.9`). Bun is installed at `~/.bun/bin`.
+
+### Gotcha: `bun install` and git hooks
+
+The package `prepare` scripts run `lefthook install`, which fails in Cursor Cloud because a custom `core.hooksPath` is set. This makes a bare `bun install` exit non-zero. Always install with `CI=true` so the `prepare`/lefthook step is skipped:
+
+```bash
+CI=true bun install
+```
+
+(The startup update script already does this.)
+
+### Common commands (run from repo root)
+
+- Lint: `bun run lint` (Biome over `packages` and `apps`)
+- Test (library): `bun run test`
+- Type-check library: `bun run --cwd packages/themes type-check`
+- Type-check docs: `bun run --cwd apps/docs types:check`
+- Build library: `bun run build` (outputs `packages/themes/dist`)
+- Run docs dev server: `bun run dev:docs` → http://localhost:3000
+
+The docs app depends on the library source via `workspace:*`; building the library is not required for `dev:docs` to run.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the development environment for the `@wrksz/themes` Bun monorepo and documents it for future cloud agents.

- Adds `AGENTS.md` with a `## Cursor Cloud specific instructions` section covering the workspace layout, common lint/test/build/run commands, and the key gotcha that `bun install` must run with `CI=true` (the `prepare`/`lefthook install` step otherwise fails because Cursor sets a custom `core.hooksPath`).
- Configures the startup update script: `CI=true "$HOME/.bun/bin/bun" install`.

## Verification

All run from repo root with Bun `1.3.9`:

- `bun run lint` — Biome, 57 files, no issues
- `bun run --cwd packages/themes type-check` — clean
- `bun run --cwd apps/docs types:check` — clean
- `bun run test` — 139 pass / 0 fail
- `bun run build` — library built to `packages/themes/dist`
- `bun run dev:docs` — Next.js docs site on http://localhost:3000

Hello-world: started the docs site and toggled the theme (light ⇄ dark), exercising the library's core theme-switching feature.

[themes_docs_theme_toggle_clean_demo.mp4](https://cursor.com/agents/bc-a93524d8-8eb6-439d-ac2b-141f5cddbfd6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fthemes_docs_theme_toggle_clean_demo.mp4)

[Docs site in light theme](https://cursor.com/agents/bc-a93524d8-8eb6-439d-ac2b-141f5cddbfd6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdocs_light_theme_before.webp)
[Docs site in dark theme](https://cursor.com/agents/bc-a93524d8-8eb6-439d-ac2b-141f5cddbfd6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdocs_dark_theme_after.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a93524d8-8eb6-439d-ac2b-141f5cddbfd6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a93524d8-8eb6-439d-ac2b-141f5cddbfd6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

