### PR TITLE
feat(themes): isolate typed factory contexts

### DIFF
--- a/apps/docs/tsconfig.json
+++ b/apps/docs/tsconfig.json
@@ -1,6 +1,5 @@
 {
 	"compilerOptions": {
-		"baseUrl": ".",
 		"target": "ESNext",
 		"lib": ["dom", "dom.iterable", "esnext"],
 		"allowJs": true,
@@ -17,7 +16,7 @@
 		"incremental": true,
 		"paths": {
 			"@/*": ["./src/*"],
-			"collections/*": [".source/*"]
+			"collections/*": ["./.source/*"]
 		},
 		"plugins": [
 			{

--- a/packages/themes/src/__tests__/client-provider.test.tsx
+++ b/packages/themes/src/__tests__/client-provider.test.tsx
@@ -6,7 +6,7 @@ import { serializeCookie, writeCookie } from "../core/cookie.js";
 import { ClientThemeProvider } from "../providers/client-provider.js";
 import { clearCookies } from "./setup.js";
 
-(globalThis as unknown as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT = true;
+Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
 
 function ThemeConsumer({ prefix = "" }: { prefix?: string }) {
 	const { theme, resolvedTheme, systemTheme, forcedTheme, setTheme } = useTheme();

--- a/packages/themes/src/__tests__/create-themes.test.tsx
+++ b/packages/themes/src/__tests__/create-themes.test.tsx
@@ -12,6 +12,13 @@ const { ThemeProvider, useTheme, useThemeValue, useThemeEffect } = createThemes(
 	storage: "none",
 });
 
+const paletteThemes = createThemes({
+	themes: ["ocean", "forest"] as const,
+	defaultTheme: "ocean",
+	attribute: "data-palette",
+	storage: "none",
+});
+
 function ThemeReader({ children }: { children?: ReactNode }) {
 	const { theme, setTheme } = useTheme();
 	const label = useThemeValue({
@@ -40,6 +47,18 @@ function EffectProbe({ onChange }: { onChange: (value: string) => void }) {
 		onChange(`${theme ?? "none"}:${resolvedTheme ?? "none"}`);
 	});
 	return null;
+}
+
+function PaletteReader() {
+	const { theme, setTheme } = paletteThemes.useTheme();
+	return (
+		<div>
+			<span data-testid="palette">{theme}</span>
+			<button type="button" data-testid="set-forest" onClick={() => setTheme("forest")}>
+				set forest
+			</button>
+		</div>
+	);
 }
 
 beforeEach(() => {
@@ -110,5 +129,25 @@ describe("createThemes", () => {
 		});
 
 		expect(calls).toEqual(["light:light", "dark:dark"]);
+	});
+
+	test("keeps multiple factory contexts independent when nested", () => {
+		const view = render(
+			<ThemeProvider>
+				<paletteThemes.ThemeProvider>
+					<ThemeReader />
+					<PaletteReader />
+				</paletteThemes.ThemeProvider>
+			</ThemeProvider>,
+		);
+
+		act(() => fireEvent.click(view.getByTestId("set-dark")));
+		expect(view.getByTestId("theme").textContent).toBe("dark");
+		expect(view.getByTestId("palette").textContent).toBe("ocean");
+
+		act(() => fireEvent.click(view.getByTestId("set-forest")));
+		expect(view.getByTestId("theme").textContent).toBe("dark");
+		expect(view.getByTestId("palette").textContent).toBe("forest");
+		expect(document.documentElement.getAttribute("data-palette")).toBe("forest");
 	});
 });

--- a/packages/themes/src/__tests__/type-inference.tsx
+++ b/packages/themes/src/__tests__/type-inference.tsx
@@ -1,17 +1,27 @@
 import type { ReactNode } from "react";
-import { useThemeValue as useStandaloneThemeValue } from "../client.js";
 import {
+	useThemeEffect as useStandaloneThemeEffect,
+	useThemeValue as useStandaloneThemeValue,
+} from "../client.js";
+import {
+	type CookieOptions,
 	type CreateThemesConfig,
 	type CreateThemesResult,
 	createThemes,
+	type ThemeColor,
 	ThemeProvider,
 	type ThemeProviderProps,
 	type ThemeValueMap,
 	type TypedThemedImageProps,
 } from "../index.js";
-import { getTheme } from "../next.js";
+import { type GetThemeOptions, getTheme } from "../next.js";
 
 function expectType<T>(_value: T): void {}
+
+type Equal<Left, Right> =
+	(<Value>() => Value extends Left ? 1 : 2) extends <Value>() => Value extends Right ? 1 : 2
+		? true
+		: false;
 
 const request = new Request("https://example.com", {
 	headers: { cookie: "theme=dark" },
@@ -25,6 +35,7 @@ const syncTheme = getTheme(request, {
 	defaultTheme: "light",
 });
 expectType<AppTheme>(syncTheme);
+expectType<Equal<typeof syncTheme, AppTheme>>(true);
 
 const asyncTheme = getTheme({
 	themes: ["light", "dark"] as const,
@@ -34,11 +45,12 @@ expectType<Promise<"light" | "dark" | "system">>(asyncTheme);
 const looseTheme = getTheme(request, { defaultTheme: "dark" });
 expectType<string>(looseTheme);
 
-// @ts-expect-error defaultTheme must be one of the configured themes or "system"
-getTheme(request, {
+const invalidGetThemeOptions = {
 	themes: appThemes,
+	// @ts-expect-error defaultTheme must be one of the configured themes or "system"
 	defaultTheme: "sepia",
-});
+} satisfies GetThemeOptions<typeof appThemes>;
+expectType<readonly AppTheme[]>(invalidGetThemeOptions.themes);
 
 const validProviderProps = {
 	children: null,
@@ -53,6 +65,31 @@ const validProviderProps = {
 	},
 } satisfies ThemeProviderProps<AppTheme>;
 expectType<readonly AppTheme[] | undefined>(validProviderProps.themes);
+
+const cookieOptions = {
+	maxAge: 3600,
+	sameSite: "Strict",
+	secure: true,
+} satisfies CookieOptions;
+expectType<CookieOptions>(cookieOptions);
+
+// @ts-expect-error exact optional properties reject explicitly undefined cookie flags
+const invalidCookieOptions: CookieOptions = { secure: undefined };
+expectType<CookieOptions>(invalidCookieOptions);
+
+const themeColor = {
+	light: "#fff",
+	dark: "#000",
+	"high-contrast": "#ff0",
+} satisfies ThemeColor<AppTheme>;
+expectType<ThemeColor<AppTheme>>(themeColor);
+
+const invalidThemeColor = {
+	light: "#fff",
+	// @ts-expect-error themeColor keys must be configured themes
+	sepia: "#704214",
+} satisfies ThemeColor<AppTheme>;
+expectType<ThemeColor<AppTheme>>(invalidThemeColor);
 
 const invalidProviderProps = {
 	children: null,
@@ -125,6 +162,14 @@ function TypedUsage(): ReactNode {
 		default: "Fallback",
 	});
 	expectType<string | undefined>(standaloneValue);
+	expectType<Equal<typeof standaloneValue, "Light" | "High contrast" | "Fallback" | undefined>>(
+		true,
+	);
+
+	useStandaloneThemeEffect<AppTheme>((selectedTheme, resolvedTheme) => {
+		expectType<Equal<typeof selectedTheme, AppTheme | "system" | undefined>>(true);
+		expectType<Equal<typeof resolvedTheme, AppTheme | undefined>>(true);
+	});
 
 	return (
 		<typed.ThemedImage

--- a/packages/themes/src/client.ts
+++ b/packages/themes/src/client.ts
@@ -5,6 +5,7 @@ export { ThemedImage } from "./components/themed-image.js";
 export { ThemeContext, useTheme } from "./core/context.js";
 export type {
 	Attribute,
+	CookieOptions,
 	DefaultTheme,
 	ResolvedTheme,
 	StorageType,

--- a/packages/themes/src/client/provider.ts
+++ b/packages/themes/src/client/provider.ts
@@ -2,6 +2,7 @@
 
 export type {
 	Attribute,
+	CookieOptions,
 	DefaultTheme,
 	StorageType,
 	ThemeColor,

--- a/packages/themes/src/components/themed-image.tsx
+++ b/packages/themes/src/components/themed-image.tsx
@@ -2,14 +2,18 @@
 
 import type { ImgHTMLAttributes, ReactElement } from "react";
 import { ThemeContext, type ThemeContextInstance, useThemeFromContext } from "../core/context.js";
+import type { ResolvedTheme } from "../core/types.js";
 
 // Transparent 1x1 GIF - shown before theme resolves to avoid hydration mismatch
 const TRANSPARENT_FALLBACK =
 	"data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7";
 
-export type ThemedImageProps = Omit<ImgHTMLAttributes<HTMLImageElement>, "src" | "alt"> & {
+export type ThemedImageProps<Themes extends string = string> = Omit<
+	ImgHTMLAttributes<HTMLImageElement>,
+	"src" | "alt"
+> & {
 	/** Map of theme name to image source */
-	src: Record<string, string>;
+	src: Record<ResolvedTheme<Themes>, string>;
 	/**
 	 * Shown before the theme resolves on the client.
 	 * Defaults to a transparent 1x1 GIF to avoid hydration mismatch.
@@ -17,17 +21,20 @@ export type ThemedImageProps = Omit<ImgHTMLAttributes<HTMLImageElement>, "src" |
 	fallback?: string;
 	/** Alt text (required for accessibility) */
 	alt: string;
-	/** @internal Context used by createThemes factory instances. */
-	themeContext?: ThemeContextInstance;
 };
 
-export function ThemedImage({
+type InternalThemedImageProps<Themes extends string> = ThemedImageProps<Themes> & {
+	/** @internal Context used by createThemes factory instances. */
+	themeContext?: ThemeContextInstance<Themes>;
+};
+
+export function ThemedImage<Themes extends string = string>({
 	src,
 	fallback = TRANSPARENT_FALLBACK,
 	alt,
-	themeContext = ThemeContext,
+	themeContext = ThemeContext as ThemeContextInstance<Themes>,
 	...props
-}: ThemedImageProps): ReactElement {
+}: InternalThemedImageProps<Themes>): ReactElement {
 	const { resolvedTheme } = useThemeFromContext(themeContext);
 
 	const resolvedSrc = (resolvedTheme && src[resolvedTheme]) || fallback;

--- a/packages/themes/src/components/themed-image.tsx
+++ b/packages/themes/src/components/themed-image.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type { ImgHTMLAttributes, ReactElement } from "react";
-import { useTheme } from "../core/context.js";
+import { ThemeContext, type ThemeContextInstance, useThemeFromContext } from "../core/context.js";
 
 // Transparent 1x1 GIF - shown before theme resolves to avoid hydration mismatch
 const TRANSPARENT_FALLBACK =
@@ -17,15 +17,18 @@ export type ThemedImageProps = Omit<ImgHTMLAttributes<HTMLImageElement>, "src" |
 	fallback?: string;
 	/** Alt text (required for accessibility) */
 	alt: string;
+	/** @internal Context used by createThemes factory instances. */
+	themeContext?: ThemeContextInstance;
 };
 
 export function ThemedImage({
 	src,
 	fallback = TRANSPARENT_FALLBACK,
 	alt,
+	themeContext = ThemeContext,
 	...props
 }: ThemedImageProps): ReactElement {
-	const { resolvedTheme } = useTheme();
+	const { resolvedTheme } = useThemeFromContext(themeContext);
 
 	const resolvedSrc = (resolvedTheme && src[resolvedTheme]) || fallback;
 

--- a/packages/themes/src/core/context.ts
+++ b/packages/themes/src/core/context.ts
@@ -1,22 +1,25 @@
 import { type Context, createContext, useContext } from "react";
 import type { DefaultTheme, ThemeContextValue } from "./types.js";
 
-export type ThemeContextInstance = Context<ThemeContextValue<string> | undefined>;
+export type ThemeContextInstance<Themes extends string = string> = Context<
+	ThemeContextValue<Themes> | undefined
+>;
 
-export function createThemeContext(): ThemeContextInstance {
-	return createContext<ThemeContextValue<string> | undefined>(undefined);
+export function createThemeContext<Themes extends string = string>(): ThemeContextInstance<Themes> {
+	return createContext<ThemeContextValue<Themes> | undefined>(undefined);
 }
 
 export const ThemeContext: ThemeContextInstance = createThemeContext();
 
-export function useThemeFromContext<Themes extends string = DefaultTheme>(
-	context: ThemeContextInstance,
+export function useThemeFromContext<Themes extends string>(
+	context: ThemeContextInstance<Themes>,
 ): ThemeContextValue<Themes> {
 	const value = useContext(context);
 	if (!value) throw new Error("useTheme must be used within its ThemeProvider");
-	return value as unknown as ThemeContextValue<Themes>;
+	return value;
 }
 
 export function useTheme<Themes extends string = DefaultTheme>(): ThemeContextValue<Themes> {
-	return useThemeFromContext<Themes>(ThemeContext);
+	// The global context is intentionally unbound; callers select its theme union.
+	return useThemeFromContext(ThemeContext) as unknown as ThemeContextValue<Themes>;
 }

--- a/packages/themes/src/core/context.ts
+++ b/packages/themes/src/core/context.ts
@@ -1,16 +1,22 @@
 import { type Context, createContext, useContext } from "react";
 import type { DefaultTheme, ThemeContextValue } from "./types.js";
 
-export const ThemeContext: Context<ThemeContextValue<string> | undefined> = createContext<
-	ThemeContextValue<string> | undefined
->(undefined);
+export type ThemeContextInstance = Context<ThemeContextValue<string> | undefined>;
+
+export function createThemeContext(): ThemeContextInstance {
+	return createContext<ThemeContextValue<string> | undefined>(undefined);
+}
+
+export const ThemeContext: ThemeContextInstance = createThemeContext();
+
+export function useThemeFromContext<Themes extends string = DefaultTheme>(
+	context: ThemeContextInstance,
+): ThemeContextValue<Themes> {
+	const value = useContext(context);
+	if (!value) throw new Error("useTheme must be used within its ThemeProvider");
+	return value as unknown as ThemeContextValue<Themes>;
+}
 
 export function useTheme<Themes extends string = DefaultTheme>(): ThemeContextValue<Themes> {
-	const ctx = useContext(ThemeContext);
-
-	if (!ctx) {
-		throw new Error("useTheme must be used within a ThemeProvider");
-	}
-
-	return ctx as unknown as ThemeContextValue<Themes>;
+	return useThemeFromContext<Themes>(ThemeContext);
 }

--- a/packages/themes/src/core/types.ts
+++ b/packages/themes/src/core/types.ts
@@ -33,7 +33,9 @@ export type CookieOptions = {
 };
 
 /** Per-theme colors for meta theme-color, or a single string for all themes */
-export type ThemeColor = string | Partial<Record<string, string>>;
+export type ThemeColor<Themes extends string = string> =
+	| string
+	| Partial<Record<ResolvedTheme<Themes>, string>>;
 
 export type ThemeScriptAttributes = ScriptHTMLAttributes<HTMLScriptElement> & {
 	[key: `data-${string}`]: string | undefined;
@@ -72,7 +74,7 @@ export type ThemeProviderProps<Themes extends string = DefaultTheme> = {
 	/** Called when theme changes. Receives the selected theme (may be "system"), not the resolved value. When the system preference changes while the theme is set to "system", fires with the resolved value ("light" | "dark"). */
 	onThemeChange?: (theme: ThemeSelection<Themes>) => void;
 	/** Colors for meta theme-color tag, per theme or a single value */
-	themeColor?: ThemeColor;
+	themeColor?: ThemeColor<Themes>;
 	/** Always follow system preference changes, even after setTheme was called */
 	followSystem?: boolean;
 	/** Server-provided theme that overrides storage on mount (e.g. from a database). User can still call setTheme to change it. */

--- a/packages/themes/src/factory/create-themes.tsx
+++ b/packages/themes/src/factory/create-themes.tsx
@@ -1,9 +1,15 @@
 "use client";
 
-import type { DependencyList, EffectCallback, ReactElement } from "react";
+import {
+	type DependencyList,
+	type EffectCallback,
+	type ReactElement,
+	useEffect,
+	useRef,
+} from "react";
 import type { ThemedImageProps } from "../components/themed-image.js";
 import { ThemedImage } from "../components/themed-image.js";
-import { useTheme } from "../core/context.js";
+import { createThemeContext, useThemeFromContext } from "../core/context.js";
 import { resolveThemeValue, type ThemeValueMap } from "../core/theme-value.js";
 import type {
 	ResolvedTheme,
@@ -11,7 +17,6 @@ import type {
 	ThemeProviderProps,
 	ThemeSelection,
 } from "../core/types.js";
-import { useThemeEffect } from "../hooks/use-theme-effect.js";
 import { ClientThemeProvider } from "../providers/client-provider.js";
 
 export type { ThemeValueMap } from "../core/theme-value.js";
@@ -45,6 +50,7 @@ export function createThemes<const Themes extends readonly [string, ...string[]]
 	config: CreateThemesConfig<Themes>,
 ): CreateThemesResult<Themes> {
 	const defaults = config;
+	const context = createThemeContext();
 	type ThemeName = Themes[number];
 
 	function TypedThemeProvider(
@@ -55,11 +61,11 @@ export function createThemes<const Themes extends readonly [string, ...string[]]
 			...props,
 			themes: defaults.themes,
 		} satisfies ThemeProviderProps<ThemeName>;
-		return <ClientThemeProvider {...merged} />;
+		return <ClientThemeProvider {...merged} themeContext={context} />;
 	}
 
 	function useTypedTheme(): ThemeContextValue<ThemeName> {
-		return useTheme<ThemeName>();
+		return useThemeFromContext<ThemeName>(context);
 	}
 
 	function useTypedThemeValue<Value>(map: ThemeValueMap<ThemeName, Value>): Value | undefined {
@@ -74,16 +80,19 @@ export function createThemes<const Themes extends readonly [string, ...string[]]
 		) => ReturnType<EffectCallback>,
 		deps: DependencyList = [],
 	): void {
-		useThemeEffect((theme, resolvedTheme) => {
-			return effect(
-				theme as ThemeSelection<ThemeName> | undefined,
-				resolvedTheme as ResolvedTheme<ThemeName> | undefined,
-			);
-		}, deps);
+		const { theme, resolvedTheme } = useTypedTheme();
+		const isFirstRender = useRef(true);
+		useEffect(() => {
+			if (isFirstRender.current) {
+				isFirstRender.current = false;
+				return;
+			}
+			return effect(theme, resolvedTheme);
+		}, [theme, resolvedTheme, effect, ...deps]);
 	}
 
 	function TypedThemedImage(props: TypedThemedImageProps<ThemeName>): ReactElement {
-		return <ThemedImage {...(props as ThemedImageProps)} />;
+		return <ThemedImage {...(props as ThemedImageProps)} themeContext={context} />;
 	}
 
 	return {

--- a/packages/themes/src/factory/create-themes.tsx
+++ b/packages/themes/src/factory/create-themes.tsx
@@ -21,9 +21,7 @@ import { ClientThemeProvider } from "../providers/client-provider.js";
 
 export type { ThemeValueMap } from "../core/theme-value.js";
 
-export type TypedThemedImageProps<Themes extends string> = Omit<ThemedImageProps, "src"> & {
-	src: Record<ResolvedTheme<Themes>, string>;
-};
+export type TypedThemedImageProps<Themes extends string> = ThemedImageProps<Themes>;
 
 export type CreateThemesConfig<Themes extends readonly string[]> = Omit<
 	ThemeProviderProps<Themes[number]>,
@@ -50,8 +48,8 @@ export function createThemes<const Themes extends readonly [string, ...string[]]
 	config: CreateThemesConfig<Themes>,
 ): CreateThemesResult<Themes> {
 	const defaults = config;
-	const context = createThemeContext();
 	type ThemeName = Themes[number];
+	const context = createThemeContext<ThemeName>();
 
 	function TypedThemeProvider(
 		props: Omit<ThemeProviderProps<ThemeName>, "themes">,
@@ -92,7 +90,7 @@ export function createThemes<const Themes extends readonly [string, ...string[]]
 	}
 
 	function TypedThemedImage(props: TypedThemedImageProps<ThemeName>): ReactElement {
-		return <ThemedImage {...(props as ThemedImageProps)} themeContext={context} />;
+		return <ThemedImage {...props} themeContext={context} />;
 	}
 
 	return {

--- a/packages/themes/src/get-theme.ts
+++ b/packages/themes/src/get-theme.ts
@@ -19,6 +19,12 @@ type UntypedGetThemeOptions = Omit<GetThemeOptions, "themes"> & {
 	themes?: undefined;
 };
 
+type RuntimeGetThemeOptions = {
+	storageKey?: string | undefined;
+	defaultTheme?: string | undefined;
+	themes?: readonly string[] | undefined;
+};
+
 function safeDecodeURIComponent(value: string): string | null {
 	try {
 		return decodeURIComponent(value);
@@ -77,11 +83,12 @@ export function getTheme<
 ): Promise<GetThemeResult<Themes, DefaultThemeValue>>;
 export function getTheme(options?: UntypedGetThemeOptions): Promise<string>;
 export function getTheme(
-	requestOrOptions?: Request | GetThemeOptions,
-	options?: GetThemeOptions,
+	requestOrOptions?: Request | RuntimeGetThemeOptions,
+	options?: RuntimeGetThemeOptions,
 ): string | Promise<string> {
 	const isRequest = requestOrOptions instanceof Request;
-	const opts = (isRequest ? options : (requestOrOptions as GetThemeOptions | undefined)) ?? {};
+	const opts =
+		(isRequest ? options : (requestOrOptions as RuntimeGetThemeOptions | undefined)) ?? {};
 	const { storageKey = "theme", defaultTheme = "system", themes } = opts;
 
 	if (isRequest) {

--- a/packages/themes/src/hooks/use-theme-effect.ts
+++ b/packages/themes/src/hooks/use-theme-effect.ts
@@ -2,19 +2,20 @@
 
 import { type DependencyList, type EffectCallback, useEffect, useRef } from "react";
 import { useTheme } from "../core/context.js";
+import type { DefaultTheme, ResolvedTheme, ThemeSelection } from "../core/types.js";
 
 /**
  * Like useEffect, but runs only after the first render
  * and only when theme state changes.
  */
-export function useThemeEffect(
+export function useThemeEffect<Themes extends string = DefaultTheme>(
 	effect: (
-		theme: string | undefined,
-		resolvedTheme: string | undefined,
+		theme: ThemeSelection<Themes> | undefined,
+		resolvedTheme: ResolvedTheme<Themes> | undefined,
 	) => ReturnType<EffectCallback>,
 	deps: DependencyList = [],
 ): void {
-	const { theme, resolvedTheme } = useTheme();
+	const { theme, resolvedTheme } = useTheme<Themes>();
 	const isFirstRender = useRef(true);
 
 	useEffect(() => {

--- a/packages/themes/src/hooks/use-theme-value.ts
+++ b/packages/themes/src/hooks/use-theme-value.ts
@@ -11,7 +11,9 @@ import { resolveThemeValue, type ThemeValueMap } from "../core/theme-value.js";
  * const label = useThemeValue({ light: "Switch to dark", dark: "Switch to light" });
  * const color = useThemeValue({ light: "#fff", dark: "#000", purple: "#1a0a2e" });
  */
-export function useThemeValue<Value>(map: ThemeValueMap<string, Value>): Value | undefined {
+export function useThemeValue<const Map extends ThemeValueMap<string, unknown>>(
+	map: Map,
+): Map[keyof Map] | undefined {
 	const { theme, resolvedTheme } = useTheme<string>();
-	return resolveThemeValue(map, theme, resolvedTheme);
+	return resolveThemeValue(map, theme, resolvedTheme) as Map[keyof Map] | undefined;
 }

--- a/packages/themes/src/index.ts
+++ b/packages/themes/src/index.ts
@@ -2,6 +2,7 @@
 
 export type {
 	Attribute,
+	CookieOptions,
 	DefaultTheme,
 	ResolvedTheme,
 	StorageType,

--- a/packages/themes/src/next.ts
+++ b/packages/themes/src/next.ts
@@ -1,5 +1,6 @@
 export type {
 	Attribute,
+	CookieOptions,
 	DefaultTheme,
 	ResolvedTheme,
 	StorageType,

--- a/packages/themes/src/providers/client-next-provider.tsx
+++ b/packages/themes/src/providers/client-next-provider.tsx
@@ -7,28 +7,27 @@ import { ClientThemeProvider } from "./client-provider.js";
 
 const DEFAULT_THEMES: string[] = ["light", "dark"];
 
-export function ClientNextThemeProvider<Themes extends string = DefaultTheme>({
-	children,
-	themes = DEFAULT_THEMES as Themes[],
-	forcedTheme,
-	enableSystem = true,
-	defaultTheme,
-	attribute = "class",
-	value: valueMap,
-	target = "html",
-	disableTransitionOnChange = false,
-	storage = "localStorage",
-	storageKey = "theme",
-	enableColorScheme = true,
-	nonce,
-	onThemeChange,
-	themeColor,
-	followSystem = false,
-	initialTheme,
-	cookieOptions,
-	scriptProps,
-	onStorageError,
-}: ThemeProviderProps<Themes>): ReactElement {
+export function ClientNextThemeProvider<Themes extends string = DefaultTheme>(
+	props: ThemeProviderProps<Themes>,
+): ReactElement {
+	const {
+		themes = DEFAULT_THEMES as Themes[],
+		forcedTheme,
+		enableSystem = true,
+		defaultTheme,
+		attribute = "class",
+		value: valueMap,
+		target = "html",
+		disableTransitionOnChange = false,
+		storage = "localStorage",
+		storageKey = "theme",
+		enableColorScheme = true,
+		nonce,
+		themeColor,
+		followSystem = false,
+		initialTheme,
+		scriptProps,
+	} = props;
 	const resolvedDefault = (defaultTheme ?? (enableSystem ? "system" : "light")) as string;
 	const inserted = useRef(false);
 
@@ -63,27 +62,5 @@ export function ClientNextThemeProvider<Themes extends string = DefaultTheme>({
 		);
 	});
 
-	return (
-		<ClientThemeProvider
-			themes={themes}
-			forcedTheme={forcedTheme}
-			enableSystem={enableSystem}
-			defaultTheme={defaultTheme}
-			attribute={attribute}
-			value={valueMap}
-			target={target}
-			disableTransitionOnChange={disableTransitionOnChange}
-			storage={storage}
-			storageKey={storageKey}
-			enableColorScheme={enableColorScheme}
-			themeColor={themeColor}
-			followSystem={followSystem}
-			onThemeChange={onThemeChange}
-			initialTheme={initialTheme}
-			cookieOptions={cookieOptions}
-			onStorageError={onStorageError}
-		>
-			{children}
-		</ClientThemeProvider>
-	);
+	return <ClientThemeProvider {...props} />;
 }

--- a/packages/themes/src/providers/client-provider.tsx
+++ b/packages/themes/src/providers/client-provider.tsx
@@ -10,13 +10,18 @@ import {
 import { ThemeContext, type ThemeContextInstance } from "../core/context.js";
 import { createThemeStore } from "../core/store.js";
 import { isThemeSelection } from "../core/theme-validation.js";
-import type { DefaultTheme, ThemeContextValue, ThemeProviderProps } from "../core/types.js";
+import type {
+	DefaultTheme,
+	ResolvedTheme,
+	ThemeContextValue,
+	ThemeProviderProps,
+} from "../core/types.js";
 
 const DEFAULT_THEMES: string[] = ["light", "dark"];
 
 export type ClientThemeProviderProps<Themes extends string = DefaultTheme> =
 	ThemeProviderProps<Themes> & {
-		themeContext?: ThemeContextInstance;
+		themeContext?: ThemeContextInstance<Themes>;
 	};
 
 export function ClientThemeProvider<Themes extends string = DefaultTheme>({
@@ -38,7 +43,7 @@ export function ClientThemeProvider<Themes extends string = DefaultTheme>({
 	initialTheme,
 	cookieOptions,
 	onStorageError,
-	themeContext = ThemeContext,
+	themeContext = ThemeContext as ThemeContextInstance<Themes>,
 }: ClientThemeProviderProps<Themes>): ReactElement {
 	const requestedDefault = defaultTheme ?? (enableSystem ? "system" : themes[0]);
 	const resolvedDefault = (
@@ -65,10 +70,10 @@ export function ClientThemeProvider<Themes extends string = DefaultTheme>({
 
 	const validForcedTheme = forcedTheme && themes.includes(forcedTheme) ? forcedTheme : undefined;
 	const selectedTheme = validForcedTheme ?? theme;
-	const resolvedTheme =
+	const resolvedTheme: ResolvedTheme<Themes> | undefined =
 		selectedTheme === "system" || selectedTheme === undefined
-			? (systemTheme as Themes | undefined)
-			: (selectedTheme as Themes);
+			? (systemTheme as ResolvedTheme<Themes> | undefined)
+			: (selectedTheme as ResolvedTheme<Themes>);
 
 	const isValidTheme = useCallback(
 		(candidate: string): candidate is Themes | "system" =>
@@ -255,13 +260,14 @@ export function ClientThemeProvider<Themes extends string = DefaultTheme>({
 		],
 	);
 
-	const contextValue: ThemeContextValue<string> = {
-		theme: validForcedTheme ?? theme,
+	const contextTheme = theme !== undefined && isValidTheme(theme) ? theme : undefined;
+	const contextValue: ThemeContextValue<Themes> = {
+		theme: validForcedTheme ?? contextTheme,
 		resolvedTheme,
 		systemTheme,
 		forcedTheme: validForcedTheme,
 		themes,
-		setTheme: setTheme as ThemeContextValue<string>["setTheme"],
+		setTheme,
 	};
 	const ContextProvider = themeContext.Provider;
 

--- a/packages/themes/src/providers/client-provider.tsx
+++ b/packages/themes/src/providers/client-provider.tsx
@@ -7,7 +7,7 @@ import {
 	readStoredTheme,
 	writeStoredTheme,
 } from "../core/client-dom.js";
-import { ThemeContext } from "../core/context.js";
+import { ThemeContext, type ThemeContextInstance } from "../core/context.js";
 import { createThemeStore } from "../core/store.js";
 import { isThemeSelection } from "../core/theme-validation.js";
 import type { DefaultTheme, ThemeContextValue, ThemeProviderProps } from "../core/types.js";
@@ -15,7 +15,9 @@ import type { DefaultTheme, ThemeContextValue, ThemeProviderProps } from "../cor
 const DEFAULT_THEMES: string[] = ["light", "dark"];
 
 export type ClientThemeProviderProps<Themes extends string = DefaultTheme> =
-	ThemeProviderProps<Themes>;
+	ThemeProviderProps<Themes> & {
+		themeContext?: ThemeContextInstance;
+	};
 
 export function ClientThemeProvider<Themes extends string = DefaultTheme>({
 	children,
@@ -36,6 +38,7 @@ export function ClientThemeProvider<Themes extends string = DefaultTheme>({
 	initialTheme,
 	cookieOptions,
 	onStorageError,
+	themeContext = ThemeContext,
 }: ClientThemeProviderProps<Themes>): ReactElement {
 	const requestedDefault = defaultTheme ?? (enableSystem ? "system" : themes[0]);
 	const resolvedDefault = (
@@ -260,5 +263,7 @@ export function ClientThemeProvider<Themes extends string = DefaultTheme>({
 		themes,
 		setTheme: setTheme as ThemeContextValue<string>["setTheme"],
 	};
-	return <ThemeContext.Provider value={contextValue}>{children}</ThemeContext.Provider>;
+	const ContextProvider = themeContext.Provider;
+
+	return <ContextProvider value={contextValue}>{children}</ContextProvider>;
 }

--- a/packages/themes/src/providers/next-provider.tsx
+++ b/packages/themes/src/providers/next-provider.tsx
@@ -21,10 +21,10 @@ export async function ThemeProvider<Themes extends string = DefaultTheme>(
 		}
 	}
 
-	return (
-		<ClientNextThemeProvider
-			{...props}
-			initialTheme={(props.initialTheme ?? serverTheme) as Themes | undefined}
-		/>
+	const initialTheme = props.initialTheme ?? (serverTheme as Themes | undefined);
+	return initialTheme === undefined ? (
+		<ClientNextThemeProvider {...props} />
+	) : (
+		<ClientNextThemeProvider {...props} initialTheme={initialTheme} />
 	);
 }

--- a/packages/themes/tsconfig.json
+++ b/packages/themes/tsconfig.json
@@ -10,12 +10,24 @@
 		"allowImportingTsExtensions": true,
 		"verbatimModuleSyntax": true,
 		"noEmit": true,
+		"rootDir": ".",
+		"types": ["bun"],
 
 		"strict": true,
 		"skipLibCheck": true,
+		"exactOptionalPropertyTypes": true,
 		"noFallthroughCasesInSwitch": true,
+		"noImplicitReturns": true,
 		"noUncheckedIndexedAccess": true,
 		"noImplicitOverride": true,
+		"noUnusedLocals": false,
+		"noUnusedParameters": false,
+		"noPropertyAccessFromIndexSignature": false,
+		"noUncheckedSideEffectImports": true,
+		"allowUnreachableCode": false,
+		"allowUnusedLabels": false,
+		"isolatedModules": true,
+		"erasableSyntaxOnly": true,
 
 		"declaration": true,
 		"isolatedDeclarations": true,
@@ -24,11 +36,7 @@
 			"@/*": ["./src/*"],
 			"@wrksz/themes": ["./src/index.ts"],
 			"@wrksz/themes/*": ["./src/*"]
-		},
-
-		"noUnusedLocals": false,
-		"noUnusedParameters": false,
-		"noPropertyAccessFromIndexSignature": false
+		}
 	},
 
 	"include": ["src/**/*"],


### PR DESCRIPTION
## Stack

PR 4 of 9. Rebased onto `main` after `split/03-portable-ssr` (#34) landed. Scope is only the two commits on this branch.

## Summary

- Give every `createThemes` factory its own React context so nested factories no longer share state accidentally.
- Bind generated hooks and `ThemedImage` to the factory-specific context.
- Tighten generic relationships for theme selections, resolved themes, providers, image maps, and `getTheme`.
- Add type-inference and nested-provider tests for the public contracts.

## Preserved from earlier PR feedback

- Kept the default provider lightweight: no `systemThemeMap`, ShadowRoot/`themeRoot`, or same-document sync in the default path (#33).
- Kept CSP nonce ordering (`nonce` only applied when defined) and `enableSystem` bootstrap behavior from #34.
- Kept portable script exports (`getScript` + `ThemeScript`) and the readable bootstrap + generated source workflow.
- Bundle size stays within budget (`next-provider` ~+65 B raw / +32 B gzip vs baseline).

## Breaking changes

Potential compile-time impact: the stricter public TypeScript contracts can reject invalid theme names, incomplete resolved-theme image maps, or mismatched generic usage that previously type-checked. No public runtime export is removed.

## Verification

- Runtime factory-context tests passed.
- Public type-inference tests passed.
- Theme package and docs type-checks passed.
- Bundle-size compare against baseline passed.