### PR TITLE
feat(themes): use effect events with React 18 compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,3 +47,40 @@ jobs:
 
       - name: Bundle size baseline
         run: bun run size:compare benchmarks/baseline.json
+
+  react-compatibility:
+    name: React ${{ matrix.react }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - react: "18.3.1"
+            react-types: "18.3.23"
+            react-dom-types: "18.3.7"
+          - react: "19.2.4"
+            react-types: "19.2.14"
+            react-dom-types: "19.2.3"
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.9
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Select React version
+        run: >-
+          bun add --no-save --dev
+          react@${{ matrix.react }}
+          react-dom@${{ matrix.react }}
+          @types/react@${{ matrix.react-types }}
+          @types/react-dom@${{ matrix.react-dom-types }}
+
+      - name: Test effect event compatibility
+        run: bun run --cwd packages/themes test src/__tests__/use-effect-event-compat.test.tsx
+
+      - name: Build
+        run: bun run --cwd packages/themes build

--- a/packages/themes/src/__tests__/use-effect-event-compat.test.tsx
+++ b/packages/themes/src/__tests__/use-effect-event-compat.test.tsx
@@ -1,0 +1,28 @@
+import { afterEach, expect, test } from "bun:test";
+import { cleanup, renderHook } from "@testing-library/react";
+import { useEffect } from "react";
+import { useEffectEvent } from "../core/use-effect-event.js";
+
+afterEach(cleanup);
+
+test("effect events keep a stable identity while reading the latest callback", () => {
+	const calls: string[] = [];
+	const { rerender } = renderHook(
+		({ value, prefix }: { value: string; prefix: string }) => {
+			const onValue = useEffectEvent((next: string) => {
+				calls.push(`${prefix}:${next}`);
+			});
+
+			// biome-ignore lint/correctness/useExhaustiveDependencies: effect events are intentionally non-reactive.
+			useEffect(() => {
+				onValue(value);
+			}, [value]);
+
+			return onValue;
+		},
+		{ initialProps: { value: "light", prefix: "initial" } },
+	);
+	rerender({ value: "dark", prefix: "latest" });
+
+	expect(calls).toEqual(["initial:light", "latest:dark"]);
+});

--- a/packages/themes/src/core/use-effect-event.ts
+++ b/packages/themes/src/core/use-effect-event.ts
@@ -1,0 +1,27 @@
+"use client";
+
+import * as React from "react";
+
+type EffectEventHook = <Arguments extends unknown[], Result>(
+	callback: (...arguments_: Arguments) => Result,
+) => (...arguments_: Arguments) => Result;
+
+function useEffectEventFallback<Arguments extends unknown[], Result>(
+	callback: (...arguments_: Arguments) => Result,
+): (...arguments_: Arguments) => Result {
+	const callbackRef = React.useRef(callback);
+
+	React.useInsertionEffect(() => {
+		callbackRef.current = callback;
+	}, [callback]);
+
+	return React.useCallback((...arguments_: Arguments) => callbackRef.current(...arguments_), []);
+}
+
+const nativeUseEffectEvent = (
+	React as typeof React & {
+		useEffectEvent?: EffectEventHook;
+	}
+).useEffectEvent;
+
+export const useEffectEvent: EffectEventHook = nativeUseEffectEvent ?? useEffectEventFallback;

--- a/packages/themes/src/factory/create-themes.tsx
+++ b/packages/themes/src/factory/create-themes.tsx
@@ -17,6 +17,7 @@ import type {
 	ThemeProviderProps,
 	ThemeSelection,
 } from "../core/types.js";
+import { useEffectEvent } from "../core/use-effect-event.js";
 import { ClientThemeProvider } from "../providers/client-provider.js";
 
 export type { ThemeValueMap } from "../core/theme-value.js";
@@ -80,13 +81,15 @@ export function createThemes<const Themes extends readonly [string, ...string[]]
 	): void {
 		const { theme, resolvedTheme } = useTypedTheme();
 		const isFirstRender = useRef(true);
+		const onEffect = useEffectEvent(effect);
+		// biome-ignore lint/correctness/useExhaustiveDependencies: effect events are intentionally non-reactive.
 		useEffect(() => {
 			if (isFirstRender.current) {
 				isFirstRender.current = false;
 				return;
 			}
-			return effect(theme, resolvedTheme);
-		}, [theme, resolvedTheme, effect, ...deps]);
+			return onEffect(theme, resolvedTheme);
+		}, [theme, resolvedTheme, ...deps]);
 	}
 
 	function TypedThemedImage(props: TypedThemedImageProps<ThemeName>): ReactElement {

--- a/packages/themes/src/hooks/use-theme-effect.ts
+++ b/packages/themes/src/hooks/use-theme-effect.ts
@@ -3,6 +3,7 @@
 import { type DependencyList, type EffectCallback, useEffect, useRef } from "react";
 import { useTheme } from "../core/context.js";
 import type { DefaultTheme, ResolvedTheme, ThemeSelection } from "../core/types.js";
+import { useEffectEvent } from "../core/use-effect-event.js";
 
 /**
  * Like useEffect, but runs only after the first render
@@ -17,12 +18,14 @@ export function useThemeEffect<Themes extends string = DefaultTheme>(
 ): void {
 	const { theme, resolvedTheme } = useTheme<Themes>();
 	const isFirstRender = useRef(true);
+	const onEffect = useEffectEvent(effect);
 
+	// biome-ignore lint/correctness/useExhaustiveDependencies: effect events are intentionally non-reactive.
 	useEffect(() => {
 		if (isFirstRender.current) {
 			isFirstRender.current = false;
 			return;
 		}
-		return effect(theme, resolvedTheme);
-	}, [theme, resolvedTheme, effect, ...deps]);
+		return onEffect(theme, resolvedTheme);
+	}, [theme, resolvedTheme, ...deps]);
 }

--- a/packages/themes/src/providers/client-provider.tsx
+++ b/packages/themes/src/providers/client-provider.tsx
@@ -16,6 +16,7 @@ import type {
 	ThemeContextValue,
 	ThemeProviderProps,
 } from "../core/types.js";
+import { useEffectEvent } from "../core/use-effect-event.js";
 
 const DEFAULT_THEMES: string[] = ["light", "dark"];
 
@@ -81,9 +82,8 @@ export function ClientThemeProvider<Themes extends string = DefaultTheme>({
 		[themes, enableSystem],
 	);
 
-	const onThemeChangeRef = useRef(onThemeChange);
-	useEffect(() => {
-		onThemeChangeRef.current = onThemeChange;
+	const onThemeChangeEvent = useEffectEvent((next: Themes) => {
+		onThemeChange?.(next);
 	});
 
 	const applyToDom = useCallback(
@@ -109,7 +109,9 @@ export function ClientThemeProvider<Themes extends string = DefaultTheme>({
 			themeColor,
 		],
 	);
+	const applyToDomEvent = useEffectEvent(applyToDom);
 
+	// biome-ignore lint/correctness/useExhaustiveDependencies: effect events are intentionally non-reactive.
 	useEffect(() => {
 		const domWindow = getDomWindow();
 		if (!domWindow) return;
@@ -156,8 +158,8 @@ export function ClientThemeProvider<Themes extends string = DefaultTheme>({
 				if (followSystem) {
 					setStoreTheme("system");
 				}
-				applyToDom(next);
-				onThemeChangeRef.current?.(next as Themes);
+				applyToDomEvent(next);
+				onThemeChangeEvent(next as Themes);
 			}
 		};
 		mq.addEventListener?.("change", handler);
@@ -181,6 +183,7 @@ export function ClientThemeProvider<Themes extends string = DefaultTheme>({
 	]);
 
 	// Re-apply theme on bfcache restore (pageshow) and history navigation (popstate)
+	// biome-ignore lint/correctness/useExhaustiveDependencies: effect events are intentionally non-reactive.
 	useEffect(() => {
 		const domWindow = getDomWindow();
 		if (!domWindow) return;
@@ -189,7 +192,7 @@ export function ClientThemeProvider<Themes extends string = DefaultTheme>({
 			const resolved =
 				validForcedTheme ??
 				(theme === "system" || theme === undefined ? systemTheme : theme);
-			if (resolved) applyToDom(resolved);
+			if (resolved) applyToDomEvent(resolved);
 		};
 		domWindow.addEventListener("pageshow", handler);
 		domWindow.addEventListener("popstate", handler);
@@ -197,8 +200,9 @@ export function ClientThemeProvider<Themes extends string = DefaultTheme>({
 			domWindow.removeEventListener("pageshow", handler);
 			domWindow.removeEventListener("popstate", handler);
 		};
-	}, [applyToDom, validForcedTheme, getSnapshot]);
+	}, [validForcedTheme, getSnapshot]);
 
+	// biome-ignore lint/correctness/useExhaustiveDependencies: effect events are intentionally non-reactive.
 	useEffect(() => {
 		const domWindow = getDomWindow();
 		if (!domWindow) return;
@@ -211,7 +215,7 @@ export function ClientThemeProvider<Themes extends string = DefaultTheme>({
 			const resolved =
 				newTheme === "system" ? (getSnapshot().systemTheme ?? "light") : newTheme;
 			setStoreTheme(newTheme);
-			if (!validForcedTheme) applyToDom(resolved);
+			if (!validForcedTheme) applyToDomEvent(resolved);
 		};
 		domWindow.addEventListener("storage", handler);
 		return () => domWindow.removeEventListener("storage", handler);
@@ -221,7 +225,6 @@ export function ClientThemeProvider<Themes extends string = DefaultTheme>({
 		resolvedDefault,
 		isValidTheme,
 		validForcedTheme,
-		applyToDom,
 		getSnapshot,
 		setStoreTheme,
 	]);
@@ -243,7 +246,7 @@ export function ClientThemeProvider<Themes extends string = DefaultTheme>({
 
 			setStoreTheme(newTheme);
 			applyToDom(resolved);
-			onThemeChangeRef.current?.(newTheme as Themes);
+			onThemeChangeEvent(newTheme as Themes);
 
 			writeStoredTheme(storage, storageKey, newTheme, cookieOptions, onStorageError);
 		},
@@ -257,6 +260,7 @@ export function ClientThemeProvider<Themes extends string = DefaultTheme>({
 			isValidTheme,
 			getSnapshot,
 			setStoreTheme,
+			onThemeChangeEvent,
 		],
 	);
 


### PR DESCRIPTION
## Stack

PR 5 of 9. Rebased onto `split/04-typed-contexts` (#35). This cumulative upstream PR targets `main`; review the commit after `split/04-typed-contexts` for this PR's isolated scope.

## Summary

- Refactor provider and theme-effect callbacks around effect-event semantics to avoid stale closures and unnecessary subscription rebinding.
- Use native `React.useEffectEvent` when available on React 19.2+.
- Add a module-scope React 18 fallback built from `useRef`, `useInsertionEffect`, and `useCallback`; module-scope selection preserves hook order.
- Avoid a named `useEffectEvent` import so React 18 bundlers do not fail while loading the module.
- Keep effect events intentionally non-reactive in dependency arrays.
- Add React 18.3 and React 19.2 CI coverage plus a dedicated compatibility regression test.

## Preserved from earlier PR feedback

- Kept the default provider lightweight: no `systemThemeMap`, ShadowRoot/`themeRoot`, BroadcastChannel, or same-document sync (#33).
- Did **not** raise bundle-size thresholds or baselines.
- Kept CSP nonce ordering and `enableSystem` bootstrap behavior from #34.
- Biome formatting clean.

## Breaking changes

None. React and React DOM peers remain `^18.0.0 || ^19.0.0`; this explicitly avoids the React 19.2-only breaking bump from the original improvements branch.

## Verification

- 176 theme tests passed.
- Theme + docs type-check passed.
- Biome check passed.
- Bundle-size compare passed (`next-provider` ~+228 B raw / +112 B gzip vs baseline; within +500 / +250 budgets).