### PR TITLE
fix(next)!: remove implicit cookie reads for Next.js 16.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,11 +5,21 @@ on:
     branches: [main]
     paths:
       - "packages/themes/**"
+      - "apps/docs/**"
+      - "apps/next-16-3/**"
+      - "package.json"
+      - "bun.lock"
+      - "biome.json"
       - ".github/workflows/ci.yml"
   pull_request:
     branches: [main]
     paths:
       - "packages/themes/**"
+      - "apps/docs/**"
+      - "apps/next-16-3/**"
+      - "package.json"
+      - "bun.lock"
+      - "biome.json"
       - ".github/workflows/ci.yml"
 
 jobs:
@@ -84,3 +94,32 @@ jobs:
 
       - name: Build
         run: bun run --cwd packages/themes build
+
+  next-16-3:
+    name: Next.js 16.3 Instant Navigations
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.9
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Build library
+        run: bun run --cwd packages/themes build
+
+      - name: Type check
+        run: bun run --cwd apps/next-16-3 type-check
+
+      - name: Build fixture
+        run: bun run --cwd apps/next-16-3 build
+
+      - name: Install Chromium
+        run: bunx playwright install --with-deps chromium
+
+      - name: Test Instant Navigations
+        run: bun run --cwd apps/next-16-3 test:e2e

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,6 +119,7 @@ jobs:
         run: bun run --cwd apps/next-16-3 build
 
       - name: Install Chromium
+        working-directory: apps/next-16-3
         run: bunx playwright install --with-deps chromium
 
       - name: Test Instant Navigations

--- a/README.md
+++ b/README.md
@@ -74,7 +74,13 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
 }
 ```
 
-> **Note:** `ThemeProvider` from `@wrksz/themes/next` is an async Server Component. Use it directly in `layout.tsx` - it cannot be wrapped in a `"use client"` component. For nested providers inside Client Components, use `[ClientThemeProvider](#nested-provider-in-a-client-component)`.
+> **Note:** Use `ThemeProvider` from `@wrksz/themes/next` directly in a server `layout.tsx`. For nested providers inside Client Components, use [`ClientThemeProvider`](#nested-provider-in-a-client-component).
+
+The Next provider is static and compatible with Next.js 16.3 Instant Navigations,
+`cacheComponents`, and Partial Prefetching. It does not mutate cookies during prefetches.
+Use `getTheme()` only when server-rendered markup must depend on the cookie; under Cache
+Components, isolate that request-time read with `Suspense` or opt the route out with
+`export const instant = false`.
 
 ## Usage
 
@@ -96,7 +102,7 @@ export function ThemeToggle() {
 
 ## Zero-flash SSR with cookie storage
 
-Use `storage="cookie"` with `@wrksz/themes/next` to eliminate SSR theme flash. The provider reads the cookie server-side automatically - no boilerplate required:
+Use `storage="cookie"` with `@wrksz/themes/next` to eliminate theme flash. The static bootstrap reads the cookie synchronously before paint, so the provider remains compatible with Next.js 16.3 App Shells and Partial Prefetching:
 
 ```tsx
 // app/layout.tsx
@@ -162,7 +168,7 @@ with npm provenance from GitHub Actions.
 | `value`                     | `Record<string, string>`                                           | -                   | Map theme names to attribute values                                                                                                                                                                                                |
 | `target`                    | `string`                                                           | `"html"`            | Element to apply theme to (`"html"`, `"body"`, or a CSS selector)                                                                                                                                                                  |
 | `storageKey`                | `string`                                                           | `"theme"`           | Key used for storage                                                                                                                                                                                                               |
-| `storage`                   | `"localStorage" \| "sessionStorage" \| "cookie" \| "hybrid" \| "none"` | `"localStorage"`    | Where to persist the theme. `"hybrid"` reads from cookie first and mirrors to `localStorage` for cross-tab sync. `"cookie"` reads/writes `document.cookie` and with `@wrksz/themes/next` also reads server-side for zero-flash SSR |
+| `storage`                   | `"localStorage" \| "sessionStorage" \| "cookie" \| "hybrid" \| "none"` | `"localStorage"`    | Where to persist the theme. The bootstrap reads cookies before paint; `"hybrid"` prefers the cookie and mirrors writes to `localStorage` for cross-tab sync |
 | `disableTransitionOnChange` | `boolean \| string`                                                 | `false`             | Suppress CSS transitions when switching themes. `true` disables all. Pass a CSS `transition` value (e.g. `"background-color 0s, color 0s"`) to suppress only specific properties                                                   |
 | `followSystem`              | `boolean`                                                          | `false`             | Always follow system preference, ignores stored value on mount                                                                                                                                                                     |
 | `themeColor`                | `string \| Record<string, string>`                                  | -                   | Update `<meta name="theme-color">` on theme change                                                                                                                                                                                 |

--- a/apps/docs/content/docs/api/get-theme.mdx
+++ b/apps/docs/content/docs/api/get-theme.mdx
@@ -58,10 +58,12 @@ When `themes` is omitted, `getTheme` returns `string` because an existing cookie
 
 ## Layout - apply class directly on `<html>`
 
-The most reliable way to eliminate SSR theme flash when your CSS uses class-based selectors:
+Use this pattern when server-rendered markup itself must depend on the theme:
 
 ```tsx title="app/layout.tsx"
 import { ThemeProvider, getTheme } from "@wrksz/themes/next";
+
+export const instant = false;
 
 export default async function RootLayout({ children }: { children: React.ReactNode }) {
   const theme = await getTheme({ defaultTheme: "dark" });
@@ -78,7 +80,12 @@ export default async function RootLayout({ children }: { children: React.ReactNo
 }
 ```
 
-Setting `className` directly on `<html>` from the server guarantees the correct class is present before any CSS or JS runs - no flash even when system preference differs from stored theme.
+`getTheme()` calls the request-time `cookies()` API. With Cache Components enabled, reading it
+for the root `<html>` class blocks prerendering, so this example opts out with
+`export const instant = false`. For Instant Navigations, keep `ThemeProvider` static and let its
+bootstrap read the cookie before paint. If only a subtree needs server theme data, move the
+`getTheme()` call into an async child wrapped in `<Suspense>` so the rest of the App Shell remains
+prefetchable.
 
 ## Options
 

--- a/apps/docs/content/docs/api/theme-provider.mdx
+++ b/apps/docs/content/docs/api/theme-provider.mdx
@@ -27,10 +27,10 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
 ```
 
 <Callout type="warn">
-  `ThemeProvider` from `@wrksz/themes/next` is an async Server Component. It must be used directly in a server component (e.g. `layout.tsx`) - it cannot be wrapped in a `"use client"` component. If you are migrating from `next-themes` and have a wrapper like this, remove it and use `ThemeProvider` directly in your layout.
+  Use `ThemeProvider` from `@wrksz/themes/next` directly in a server layout. The `next` entry also exports the server-only `getTheme` helper, so it is not a client-module entry. For nested providers inside Client Components, use [`ClientThemeProvider`](/docs/api/client-theme-provider).
 
   ```tsx
-  // ❌ will throw: async Client Component error
+  // ❌ do not import the Next server entry from a client module
   "use client";
   import { ThemeProvider } from "@wrksz/themes/next";
   export function Providers({ children }) {
@@ -51,8 +51,6 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
     );
   }
   ```
-
-  For nested providers inside Client Components, use [`ClientThemeProvider`](/docs/api/client-theme-provider) instead.
 </Callout>
 
 ## Props
@@ -69,7 +67,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
 | `value` | `Record<string, string>` | - | Map theme names to attribute values |
 | `target` | `string` | `"html"` | Element to apply theme to (`"html"`, `"body"`, or a CSS selector) |
 | `storageKey` | `string` | `"theme"` | Key used for storage |
-| `storage` | `"localStorage" \| "sessionStorage" \| "cookie" \| "hybrid" \| "none"` | `"localStorage"` | Where to persist the theme. `"hybrid"` reads from cookie first (SSR-safe) and mirrors to `localStorage` for cross-tab sync. `"cookie"` reads/writes `document.cookie` and with `@wrksz/themes/next` also reads server-side. |
+| `storage` | `"localStorage" \| "sessionStorage" \| "cookie" \| "hybrid" \| "none"` | `"localStorage"` | Where to persist the theme. The bootstrap reads cookies synchronously before paint. `"hybrid"` prefers the cookie and mirrors writes to `localStorage` for cross-tab sync. |
 | `cookieOptions` | `CookieOptions` | - | Cookie attributes applied when writing the theme cookie. Only used when `storage="cookie"`. See [CookieOptions](#cookieoptions). |
 | `disableTransitionOnChange` | `boolean \| string` | `false` | Suppress CSS transitions on initial load and when switching themes. `true` disables all transitions. Pass a CSS `transition` value (e.g. `"background-color 0s, color 0s"`) to suppress only specific properties while keeping others (transforms, opacity, etc.) intact. |
 | `followSystem` | `boolean` | `false` | Always follow system preference, ignores stored value on mount |
@@ -158,7 +156,7 @@ export default async function RootLayout({ children }) {
 
 ### Cookie storage (zero-flash SSR)
 
-When using `@wrksz/themes/next`, `storage="cookie"` automatically reads the theme cookie server-side and renders the correct class on `<html>` from the first byte - no flash for any user, no boilerplate:
+When using `@wrksz/themes/next`, `storage="cookie"` keeps the provider in the static App Shell. Its bootstrap reads `document.cookie` synchronously and applies the class before the first paint:
 
 ```tsx title="app/layout.tsx"
 import { ThemeProvider } from "@wrksz/themes/next";
@@ -181,7 +179,7 @@ export default function RootLayout({ children }) {
 }
 ```
 
-The provider reads `document.cookie` on the client and `cookies()` from `next/headers` on the server. Theme changes are written to the cookie automatically.
+Theme changes are written to the cookie automatically. If server-rendered markup must also depend on the theme, use [`getTheme`](/docs/api/get-theme) explicitly.
 
 <Callout type="warn">
   Cookie storage does not support cross-tab theme sync. If you need cross-tab sync, use `localStorage` with [`initialTheme`](/docs/examples/server-theme).
@@ -193,7 +191,7 @@ The provider reads `document.cookie` on the client and `cookies()` from `next/he
 
 - **Read priority:** cookie first, then `localStorage`
 - **Writes:** cookie and `localStorage`
-- **SSR:** cookie is available server-side with `@wrksz/themes/next`
+- **App Shell:** the bootstrap reads the cookie without making the layout request-time dynamic
 - **Cross-tab:** changes propagate through the `storage` event
 
 ```tsx title="app/layout.tsx"
@@ -208,6 +206,30 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         </ThemeProvider>
       </body>
     </html>
+  );
+}
+```
+
+### Next.js 16.3 Instant Navigations
+
+`ThemeProvider` does not call request-time APIs, so it can stay in a reusable App Shell when
+`cacheComponents` and `partialPrefetching` are enabled. Prefetches only render the static
+provider configuration; they never write theme cookies.
+
+`next/root-params` is available by default in Next.js 16.3. Themes do not require a root-param
+integration. If your product intentionally stores a different theme per tenant or locale, scope
+the key in your app:
+
+```tsx title="app/[tenant]/layout.tsx"
+import { tenant } from "next/root-params";
+import { ThemeProvider } from "@wrksz/themes/next";
+
+export default async function TenantLayout({ children }) {
+  const currentTenant = await tenant();
+  return (
+    <ThemeProvider storageKey={`theme-${currentTenant}`}>
+      {children}
+    </ThemeProvider>
   );
 }
 ```

--- a/apps/docs/content/docs/examples/server-theme.mdx
+++ b/apps/docs/content/docs/examples/server-theme.mdx
@@ -5,7 +5,7 @@ description: Eliminate SSR theme flash with cookie storage or a custom server-si
 
 ## Cookie storage
 
-The simplest way to eliminate SSR theme flash. Use `storage="cookie"` with `@wrksz/themes/next` - the provider reads the cookie server-side automatically, no boilerplate required:
+The simplest way to eliminate theme flash. Use `storage="cookie"` with `@wrksz/themes/next` - its static bootstrap reads the cookie synchronously before paint:
 
 ```tsx title="app/layout.tsx"
 import { ThemeProvider } from "@wrksz/themes/next";
@@ -28,7 +28,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
 }
 ```
 
-Theme changes are written to `document.cookie` automatically. On subsequent requests the server reads the cookie via `cookies()` from `next/headers` and injects the correct class before the first paint.
+Theme changes are written to `document.cookie` automatically. On subsequent documents the bootstrap applies the stored class before React hydrates, without making the App Shell request-time dynamic.
 
 <Callout type="info">
   Flash may still appear in Next.js development mode - this is expected. Next.js dev mode does not fully replicate SSR behavior. The flash disappears in production builds.

--- a/apps/docs/content/docs/migration.mdx
+++ b/apps/docs/content/docs/migration.mdx
@@ -41,7 +41,7 @@ That's it for most apps.
 
 ## Step 3: Remove the "use client" wrapper
 
-`ThemeProvider` from `@wrksz/themes/next` is an async Server Component. If you have a client wrapper (common in Next.js `next-themes` setups), remove it:
+`@wrksz/themes/next` is the server-layout entry and also exports the server-only `getTheme` helper. If you have a client wrapper (common in Next.js `next-themes` setups), remove it:
 
 ```diff
 - "use client";

--- a/apps/docs/content/docs/migration.mdx
+++ b/apps/docs/content/docs/migration.mdx
@@ -39,6 +39,13 @@ description: Step-by-step guide for migrating from next-themes to @wrksz/themes.
 
 That's it for most apps.
 
+## Upgrading from 1.x
+
+`ThemeProvider` from `@wrksz/themes/next` no longer reads the request cookie implicitly and no longer sets `initialTheme` for you.
+
+- For zero-flash theme application, keep using cookie or hybrid storage. The pre-hydration bootstrap still reads the stored theme before paint.
+- If server-rendered markup must depend on the cookie (for example setting `<html className={theme}>`), call [`getTheme`](/docs/api/get-theme) explicitly and pass `initialTheme`, and opt the layout out of Instant Navigations with `export const instant = false` when that request-time read would block the static App Shell.
+
 ## Step 3: Remove the "use client" wrapper
 
 `@wrksz/themes/next` is the server-layout entry and also exports the server-only `getTheme` helper. If you have a client wrapper (common in Next.js `next-themes` setups), remove it:

--- a/apps/docs/content/docs/migration.mdx
+++ b/apps/docs/content/docs/migration.mdx
@@ -46,6 +46,26 @@ That's it for most apps.
 - For zero-flash theme application, keep using cookie or hybrid storage. The pre-hydration bootstrap still reads the stored theme before paint.
 - If server-rendered markup must depend on the cookie (for example setting `<html className={theme}>`), call [`getTheme`](/docs/api/get-theme) explicitly and pass `initialTheme`, and opt the layout out of Instant Navigations with `export const instant = false` when that request-time read would block the static App Shell.
 
+```tsx title="app/layout.tsx"
+import { ThemeProvider, getTheme } from "@wrksz/themes/next";
+
+export const instant = false;
+
+export default async function RootLayout({ children }) {
+  const theme = await getTheme();
+
+  return (
+    <html className={theme} suppressHydrationWarning>
+      <body>
+        <ThemeProvider storage="cookie" initialTheme={theme}>
+          {children}
+        </ThemeProvider>
+      </body>
+    </html>
+  );
+}
+```
+
 ## Step 3: Remove the "use client" wrapper
 
 `@wrksz/themes/next` is the server-layout entry and also exports the server-only `getTheme` helper. If you have a client wrapper (common in Next.js `next-themes` setups), remove it:

--- a/apps/docs/content/docs/why-not-next-themes.mdx
+++ b/apps/docs/content/docs/why-not-next-themes.mdx
@@ -58,7 +58,7 @@ This means switching from `"dark high-contrast"` to `"light"` correctly removes 
 <ThemeProvider storage="cookie">
 ```
 
-`storage="cookie"` is especially useful with `@wrksz/themes/next` - the provider reads the cookie server-side automatically, eliminating SSR theme flash without any manual boilerplate.
+`storage="cookie"` is especially useful with `@wrksz/themes/next` - the static bootstrap reads the cookie before paint without opting the layout out of Next.js App Shells.
 
 ### Disable storage
 

--- a/apps/next-16-3/.gitignore
+++ b/apps/next-16-3/.gitignore
@@ -1,0 +1,5 @@
+.next/
+node_modules/
+playwright-report/
+test-results/
+*.tsbuildinfo

--- a/apps/next-16-3/next-env.d.ts
+++ b/apps/next-16-3/next-env.d.ts
@@ -1,0 +1,7 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+import "./.next/types/routes.d.ts";
+import "./.next/types/root-params.d.ts";
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/next-16-3/next.config.ts
+++ b/apps/next-16-3/next.config.ts
@@ -1,0 +1,8 @@
+import type { NextConfig } from "next";
+
+const config: NextConfig = {
+	cacheComponents: true,
+	partialPrefetching: true,
+};
+
+export default config;

--- a/apps/next-16-3/package.json
+++ b/apps/next-16-3/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "next-16-3-compat",
+  "private": true,
+  "scripts": {
+    "build": "next build",
+    "dev": "next dev",
+    "start": "next start",
+    "test:e2e": "playwright test",
+    "type-check": "next typegen && tsc --noEmit"
+  },
+  "dependencies": {
+    "@wrksz/themes": "workspace:*",
+    "next": "16.3.0-preview.8",
+    "react": "^19.2.4",
+    "react-dom": "^19.2.4"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.54.1",
+    "@types/node": "^25.5.0",
+    "@types/react": "^19.2.14",
+    "@types/react-dom": "^19.2.3",
+    "typescript": "^5.9.3"
+  }
+}

--- a/apps/next-16-3/playwright.config.ts
+++ b/apps/next-16-3/playwright.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+	testDir: "./tests",
+	timeout: 60_000,
+	use: {
+		...devices["Desktop Chrome"],
+		baseURL: "http://127.0.0.1:3137",
+	},
+	webServer: {
+		command: "bun run start --port 3137",
+		port: 3137,
+		reuseExistingServer: !process.env.CI,
+		timeout: 120_000,
+	},
+});

--- a/apps/next-16-3/src/app/[tenant]/about/page.tsx
+++ b/apps/next-16-3/src/app/[tenant]/about/page.tsx
@@ -1,0 +1,19 @@
+import Link from "next/link";
+import { ThemeControls } from "../theme-controls";
+
+export default async function AboutPage({ params }: PageProps<"/[tenant]/about">) {
+	const { tenant } = await params;
+
+	return (
+		<main>
+			<h1>{tenant} about</h1>
+			<ThemeControls />
+			<nav>
+				<Link href={`/${tenant}`}>Home</Link>
+				<Link href={tenant === "alpha" ? "/beta/about" : "/alpha/about"}>
+					Switch tenant
+				</Link>
+			</nav>
+		</main>
+	);
+}

--- a/apps/next-16-3/src/app/[tenant]/layout.tsx
+++ b/apps/next-16-3/src/app/[tenant]/layout.tsx
@@ -1,0 +1,34 @@
+import { ThemeProvider } from "@wrksz/themes/next";
+import { tenant } from "next/root-params";
+import { type ReactNode, Suspense } from "react";
+import "../globals.css";
+
+export function generateStaticParams() {
+	return [{ tenant: "alpha" }, { tenant: "beta" }];
+}
+
+async function RootParamValue() {
+	const currentTenant = await tenant();
+	return <span data-testid="root-param">{currentTenant}</span>;
+}
+
+export default function TenantLayout({ children }: { children: ReactNode }) {
+	return (
+		<html lang="en" suppressHydrationWarning>
+			<body>
+				<ThemeProvider
+					storage="hybrid"
+					defaultTheme="light"
+					scriptProps={{ "data-theme-bootstrap": "true" }}
+				>
+					<header>
+						<Suspense fallback={<span data-testid="root-param">loading</span>}>
+							<RootParamValue />
+						</Suspense>
+					</header>
+					{children}
+				</ThemeProvider>
+			</body>
+		</html>
+	);
+}

--- a/apps/next-16-3/src/app/[tenant]/layout.tsx
+++ b/apps/next-16-3/src/app/[tenant]/layout.tsx
@@ -1,7 +1,13 @@
 import { ThemeProvider } from "@wrksz/themes/next";
+import type { Metadata } from "next";
 import { tenant } from "next/root-params";
 import { type ReactNode, Suspense } from "react";
 import "../globals.css";
+
+export const metadata: Metadata = {
+	title: "wrksz themes — Next.js fixture",
+	description: "Multi-tenant fixture app for verifying @wrksz/themes with Next.js App Router.",
+};
 
 export function generateStaticParams() {
 	return [{ tenant: "alpha" }, { tenant: "beta" }];

--- a/apps/next-16-3/src/app/[tenant]/page.tsx
+++ b/apps/next-16-3/src/app/[tenant]/page.tsx
@@ -1,0 +1,17 @@
+import Link from "next/link";
+import { ThemeControls } from "./theme-controls";
+
+export default async function TenantPage({ params }: PageProps<"/[tenant]">) {
+	const { tenant } = await params;
+
+	return (
+		<main>
+			<h1>{tenant} home</h1>
+			<ThemeControls />
+			<nav>
+				<Link href={`/${tenant}/about`}>About</Link>
+				<Link href={tenant === "alpha" ? "/beta" : "/alpha"}>Switch tenant</Link>
+			</nav>
+		</main>
+	);
+}

--- a/apps/next-16-3/src/app/[tenant]/theme-controls.tsx
+++ b/apps/next-16-3/src/app/[tenant]/theme-controls.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import { useTheme } from "@wrksz/themes/client";
+
+export function ThemeControls() {
+	const { theme, setTheme } = useTheme();
+
+	return (
+		<section>
+			<p>
+				Theme: <output data-testid="theme-value">{theme ?? "loading"}</output>
+			</p>
+			<button type="button" onClick={() => setTheme("dark")}>
+				Use dark
+			</button>
+			<button type="button" onClick={() => setTheme("light")}>
+				Use light
+			</button>
+		</section>
+	);
+}

--- a/apps/next-16-3/src/app/globals.css
+++ b/apps/next-16-3/src/app/globals.css
@@ -1,0 +1,24 @@
+:root {
+	color-scheme: light;
+	font-family: system-ui, sans-serif;
+	background: white;
+	color: #171717;
+}
+
+:root.dark {
+	color-scheme: dark;
+	background: #171717;
+	color: white;
+}
+
+body {
+	margin: 0;
+	padding: 2rem;
+}
+
+nav,
+section {
+	display: flex;
+	gap: 1rem;
+	margin-block: 1rem;
+}

--- a/apps/next-16-3/tests/instant-navigation.spec.ts
+++ b/apps/next-16-3/tests/instant-navigation.spec.ts
@@ -1,0 +1,71 @@
+import { expect, test } from "@playwright/test";
+
+test("keeps the current theme across prefetched shells and root params", async ({
+	context,
+	page,
+	request,
+}) => {
+	const consoleErrors: string[] = [];
+	page.on("console", (message) => {
+		if (message.type() === "error") consoleErrors.push(message.text());
+	});
+
+	await context.addCookies([
+		{
+			name: "theme",
+			value: "dark",
+			url: "http://127.0.0.1:3137",
+		},
+	]);
+	const documentResponse = await request.get("/alpha", {
+		headers: { cookie: "theme=dark" },
+	});
+	const documentHtml = await documentResponse.text();
+	expect(documentHtml.indexOf("data-theme-bootstrap")).toBeLessThan(
+		documentHtml.indexOf("<body"),
+	);
+	expect(documentHtml).toContain("document.cookie");
+
+	await page.goto("/alpha");
+	await expect(page.locator("html")).toHaveClass(/dark/);
+	await expect(page.getByTestId("root-param")).toHaveText("alpha");
+	await expect(page.getByTestId("theme-value").filter({ visible: true })).toHaveText("dark");
+	const bootstrapScripts = page.locator("script[data-theme-bootstrap]");
+	const initialScriptCount = await bootstrapScripts.count();
+	expect(initialScriptCount).toBeGreaterThan(0);
+	const bootstrapSources = await bootstrapScripts.allTextContents();
+	expect(new Set(bootstrapSources).size).toBe(1);
+
+	await page.evaluate(() => {
+		Object.defineProperty(window, "__spaMarker", { value: true, writable: true });
+	});
+
+	// Give viewport links time to prefetch their reusable route shells before changing theme.
+	await expect(page.getByRole("link", { name: "About" })).toBeVisible();
+	await page.waitForTimeout(250);
+	await page.getByRole("button", { name: "Use light" }).click();
+	await expect(page.locator("html")).toHaveClass(/light/);
+
+	await page.getByRole("link", { name: "About" }).click();
+	await expect(page).toHaveURL("/alpha/about");
+	await expect(page.getByRole("heading", { name: "alpha about" })).toBeVisible();
+	await expect(page.locator("html")).toHaveClass(/light/);
+	await expect(bootstrapScripts).toHaveCount(initialScriptCount);
+
+	await page.getByRole("link", { name: "Switch tenant" }).click();
+	await expect(page).toHaveURL("/beta/about");
+	await expect(page.getByRole("heading", { name: "beta about" })).toBeVisible();
+	await expect(page.getByTestId("root-param").filter({ visible: true })).toHaveText("beta");
+	await expect(page.locator("html")).toHaveClass(/light/);
+
+	await page.goBack();
+	await expect(page).toHaveURL("/alpha/about");
+	await expect(page.getByRole("heading", { name: "alpha about" })).toBeVisible();
+	await expect(page.locator("html")).toHaveClass(/light/);
+
+	expect(await page.evaluate(() => Reflect.get(window, "__spaMarker"))).toBe(true);
+	expect(consoleErrors).toEqual([]);
+
+	const cookies = await context.cookies();
+	expect(cookies.find((cookie) => cookie.name === "theme")?.value).toBe("light");
+});

--- a/apps/next-16-3/tsconfig.json
+++ b/apps/next-16-3/tsconfig.json
@@ -1,0 +1,29 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "react-jsx",
+    "incremental": true,
+    "plugins": [{ "name": "next" }],
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts",
+    ".next/dev/types/**/*.ts"
+  ],
+  "exclude": ["node_modules"]
+}

--- a/bun.lock
+++ b/bun.lock
@@ -48,6 +48,22 @@
         "typescript": "^5.9.3",
       },
     },
+    "apps/next-16-3": {
+      "name": "next-16-3-compat",
+      "dependencies": {
+        "@wrksz/themes": "workspace:*",
+        "next": "16.3.0-preview.8",
+        "react": "^19.2.4",
+        "react-dom": "^19.2.4",
+      },
+      "devDependencies": {
+        "@playwright/test": "^1.54.1",
+        "@types/node": "^25.5.0",
+        "@types/react": "^19.2.14",
+        "@types/react-dom": "^19.2.3",
+        "typescript": "^5.9.3",
+      },
+    },
     "packages/themes": {
       "name": "@wrksz/themes",
       "version": "0.0.0",
@@ -902,6 +918,8 @@
 
     "next": ["next@16.2.6", "", { "dependencies": { "@next/env": "16.2.6", "@swc/helpers": "0.5.15", "baseline-browser-mapping": "^2.9.19", "caniuse-lite": "^1.0.30001579", "postcss": "8.4.31", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "16.2.6", "@next/swc-darwin-x64": "16.2.6", "@next/swc-linux-arm64-gnu": "16.2.6", "@next/swc-linux-arm64-musl": "16.2.6", "@next/swc-linux-x64-gnu": "16.2.6", "@next/swc-linux-x64-musl": "16.2.6", "@next/swc-win32-arm64-msvc": "16.2.6", "@next/swc-win32-x64-msvc": "16.2.6", "sharp": "^0.34.5" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.51.1", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-qOVgKJg1+At15NpeUP+eJgCHvTCgXsogweq87Ri/Ix7PkqQHg4sdaXmSFqKlgaIXE4kW0g25LE68W87UANlHtw=="],
 
+    "next-16-3-compat": ["next-16-3-compat@workspace:apps/next-16-3"],
+
     "next-themes": ["next-themes@0.4.6", "", { "peerDependencies": { "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc", "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc" } }, "sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA=="],
 
     "oniguruma-parser": ["oniguruma-parser@0.12.2", "", {}, "sha512-6HVa5oIrgMC6aA6WF6XyyqbhRPJrKR02L20+2+zpDtO5QAzGHAUGw5TKQvwi5vctNnRHkJYmjAhRVQF2EKdTQw=="],
@@ -1090,6 +1108,8 @@
 
     "next/postcss": ["postcss@8.4.31", "", { "dependencies": { "nanoid": "^3.3.6", "picocolors": "^1.0.0", "source-map-js": "^1.0.2" } }, "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ=="],
 
+    "next-16-3-compat/next": ["next@16.3.0-preview.8", "", { "dependencies": { "@next/env": "16.3.0-preview.8", "@swc/helpers": "0.5.15", "baseline-browser-mapping": "^2.9.19", "caniuse-lite": "^1.0.30001579", "postcss": "8.5.10", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "16.3.0-preview.8", "@next/swc-darwin-x64": "16.3.0-preview.8", "@next/swc-linux-arm64-gnu": "16.3.0-preview.8", "@next/swc-linux-arm64-musl": "16.3.0-preview.8", "@next/swc-linux-x64-gnu": "16.3.0-preview.8", "@next/swc-linux-x64-musl": "16.3.0-preview.8", "@next/swc-win32-arm64-msvc": "16.3.0-preview.8", "@next/swc-win32-x64-msvc": "16.3.0-preview.8", "sharp": "^0.35.3" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.51.1", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-c9CF1GAZnpB7iwZWCnPdSPfdrmGkvr+lGqcRuH++EIYFxb4Mk6EIve13ExuO4ghbhayQVGyP+hY8BocnQ/aHbA=="],
+
     "parse-entities/@types/unist": ["@types/unist@2.0.11", "", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
 
     "parse5/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
@@ -1097,6 +1117,26 @@
     "theme-docs/next": ["next@16.2.11", "", { "dependencies": { "@next/env": "16.2.11", "@swc/helpers": "0.5.15", "baseline-browser-mapping": "^2.9.19", "caniuse-lite": "^1.0.30001579", "postcss": "8.4.31", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "16.2.11", "@next/swc-darwin-x64": "16.2.11", "@next/swc-linux-arm64-gnu": "16.2.11", "@next/swc-linux-arm64-musl": "16.2.11", "@next/swc-linux-x64-gnu": "16.2.11", "@next/swc-linux-x64-musl": "16.2.11", "@next/swc-win32-arm64-msvc": "16.2.11", "@next/swc-win32-x64-msvc": "16.2.11", "sharp": "^0.34.5" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.51.1", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-B339zaqbyK8cmxhoAvLrcwoabwCP1wz21zSzfqxqXAemTu2BXnH7tQnfcglKv1vnMUIDBc+Hth7XODQriTZiRQ=="],
 
     "yuku-ast/@yuku-toolchain/types": ["@yuku-toolchain/types@0.6.8", "", {}, "sha512-AbUd1775RVkOxJkh8hkldIWoU6kRMTCsZFSZq8Ny53q7GkbaVe5UCfleNZ3RWCoz/ZKE8qwfeB7Cj0xqhLWsKA=="],
+
+    "next-16-3-compat/next/@next/env": ["@next/env@16.3.0-preview.8", "", {}, "sha512-OUjzx/+GzS6FwtpBVSA2Y5U+XqWBcSQwXr/kJrTrdHcwoQFVATof0RSBFj5cjBy9rMwezGkCL6/HjO2WdO+dQA=="],
+
+    "next-16-3-compat/next/@next/swc-darwin-arm64": ["@next/swc-darwin-arm64@16.3.0-preview.8", "", { "os": "darwin", "cpu": "arm64" }, "sha512-zCzL322QKv1xIPV+2atT75awK9YgceZllw2QWGTqW9nDZ/nuaVaRdWVuh3+Uy+nPnDawfBv3Mn9ANEMVh6QSEg=="],
+
+    "next-16-3-compat/next/@next/swc-darwin-x64": ["@next/swc-darwin-x64@16.3.0-preview.8", "", { "os": "darwin", "cpu": "x64" }, "sha512-Vbnekjyb60VcypFxzewH7I2bNY7ajSf811bxoJpJ0eV6ASQh+5yp99aOAsTXtVrmd/WEGdtW/qVaIKQN26lHAw=="],
+
+    "next-16-3-compat/next/@next/swc-linux-arm64-gnu": ["@next/swc-linux-arm64-gnu@16.3.0-preview.8", "", { "os": "linux", "cpu": "arm64" }, "sha512-ErpN+467Gom0TXEz1MLN9iM0vOmERiz9kQu5adCXuFlPGKd4qhDqq9JHVcA+v9zDLCL/CYVxdTwK4H39UTDTig=="],
+
+    "next-16-3-compat/next/@next/swc-linux-arm64-musl": ["@next/swc-linux-arm64-musl@16.3.0-preview.8", "", { "os": "linux", "cpu": "arm64" }, "sha512-5YIeE8mteSbOOmFWGVoc+ls373pQ+Sj6bGkEFZlMvU37xSaP4cw30M9r3wbCh0TiKHdlV3HwuaTeykEM3eAh3w=="],
+
+    "next-16-3-compat/next/@next/swc-linux-x64-gnu": ["@next/swc-linux-x64-gnu@16.3.0-preview.8", "", { "os": "linux", "cpu": "x64" }, "sha512-MBvZ/lXxG00C69hIv58gWq0CuabFRl1sxud6YHuBYouqkdPWDA3dgfFxv1WWxD1U4I70H+CH3Hpp/niaGmcqGg=="],
+
+    "next-16-3-compat/next/@next/swc-linux-x64-musl": ["@next/swc-linux-x64-musl@16.3.0-preview.8", "", { "os": "linux", "cpu": "x64" }, "sha512-OpOhuV8Ujvay6dSTLJaoQk+t3MMRx1EidH3dpL8iezvuVsrFDHrsKxSVZaouqDgg8v9Res43AisI3EiKv6LESw=="],
+
+    "next-16-3-compat/next/@next/swc-win32-arm64-msvc": ["@next/swc-win32-arm64-msvc@16.3.0-preview.8", "", { "os": "win32", "cpu": "arm64" }, "sha512-c+rZGOvBT+0D3sthh8kgxfQToJA0p0athbuDDm21WuszFtm7TpPa23a+H4J0x4d9ehrE19O+2d2M9PoB17N6wA=="],
+
+    "next-16-3-compat/next/@next/swc-win32-x64-msvc": ["@next/swc-win32-x64-msvc@16.3.0-preview.8", "", { "os": "win32", "cpu": "x64" }, "sha512-M4s+BypigoOg3mW9ZOXmyrLUaFjetqPHqdqMn7MU+AiawP/gVL7cbwp4aWP2EeObMyYlYtLMKiLyR9sYYSAY9w=="],
+
+    "next-16-3-compat/next/postcss": ["postcss@8.5.10", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ=="],
 
     "theme-docs/next/@next/env": ["@next/env@16.2.11", "", {}, "sha512-0do5A3BJ2gxWr0ZCMcD6BhW+e595jyxdTl3rXTS6lOtD8ektMiW6CO+EPwt1Eca1DBnm90r/7GdiKWBKxH++DA=="],
 

--- a/packages/themes/README.md
+++ b/packages/themes/README.md
@@ -49,8 +49,9 @@ export function ThemeToggle() {
 ## Highlights
 
 - React 19 friendly Next.js provider using `useServerInsertedHTML`.
+- Static provider compatible with Next.js 16.3 App Shells and Partial Prefetching.
 - `localStorage`, `sessionStorage`, `cookie`, `hybrid`, and disabled storage modes.
-- Zero-flash SSR when using cookie storage with `@wrksz/themes/next`.
+- Zero-flash cookie theming via a synchronous pre-paint bootstrap.
 - `initialTheme`, `themeColor`, nested providers, scoped targets, and multi-class theme values.
 - Typed `useTheme`, `useThemeValue`, `useThemeEffect`, `ThemedImage`, and `createThemes`.
 - Fine-grained client subpath exports for smaller app bundles.
@@ -73,6 +74,10 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
 	);
 }
 ```
+
+The provider itself does not call `cookies()`, so it remains part of a reusable App Shell.
+Use `getTheme()` explicitly when server-rendered markup needs the cookie; with Cache Components,
+wrap request-time themed subtrees in `Suspense` or set `export const instant = false`.
 
 ## Import Paths
 

--- a/packages/themes/src/__tests__/client-next-provider.test.tsx
+++ b/packages/themes/src/__tests__/client-next-provider.test.tsx
@@ -42,4 +42,18 @@ describe("ClientNextThemeProvider", () => {
 		expect((script as ScriptElement).props.dangerouslySetInnerHTML?.__html).toContain('"dark"');
 		expect(callback?.()).toBeNull();
 	});
+
+	test("preserves scriptProps.nonce when nonce prop is omitted", () => {
+		render(
+			<ClientNextThemeProvider scriptProps={{ nonce: "from-script-props" }}>
+				<span>content</span>
+			</ClientNextThemeProvider>,
+		);
+
+		const callback = insertedHtmlCallbacks[0];
+		expect(callback).toBeDefined();
+		const script = callback?.();
+		expect(isValidElement(script)).toBe(true);
+		expect((script as ScriptElement).props.nonce).toBe("from-script-props");
+	});
 });

--- a/packages/themes/src/__tests__/client-next-provider.test.tsx
+++ b/packages/themes/src/__tests__/client-next-provider.test.tsx
@@ -1,12 +1,13 @@
 import { afterEach, describe, expect, mock, test } from "bun:test";
+import "./setup.js";
 import { cleanup, render } from "@testing-library/react";
 import { isValidElement, type ReactElement, type ReactNode } from "react";
 
-const insertedHtml: ReactNode[] = [];
+const insertedHtmlCallbacks: Array<() => ReactNode> = [];
 
 mock.module("next/navigation", () => ({
 	useServerInsertedHTML: (callback: () => ReactNode) => {
-		insertedHtml.push(callback());
+		insertedHtmlCallbacks.push(callback);
 	},
 }));
 
@@ -14,38 +15,31 @@ const { ClientNextThemeProvider } = await import("../providers/client-next-provi
 
 type ScriptElement = ReactElement<{
 	dangerouslySetInnerHTML?: { __html?: string };
-	suppressHydrationWarning?: boolean;
 	nonce?: string;
+	suppressHydrationWarning?: boolean;
 }>;
 
 afterEach(() => {
 	cleanup();
-	insertedHtml.length = 0;
+	insertedHtmlCallbacks.length = 0;
 });
 
 describe("ClientNextThemeProvider", () => {
-	test("suppresses hydration warnings on the injected theme script", () => {
+	test("injects a nonce-bearing theme script once", () => {
 		render(
-			<ClientNextThemeProvider storage="hybrid" initialTheme="dark">
+			<ClientNextThemeProvider storage="hybrid" initialTheme="dark" nonce="test-nonce">
 				<span>content</span>
 			</ClientNextThemeProvider>,
 		);
 
-		const script = insertedHtml[0];
+		const callback = insertedHtmlCallbacks[0];
+		expect(callback).toBeDefined();
+		const script = callback?.();
 		expect(isValidElement(script)).toBe(true);
 		expect((script as ScriptElement).type).toBe("script");
 		expect((script as ScriptElement).props.suppressHydrationWarning).toBe(true);
+		expect((script as ScriptElement).props.nonce).toBe("test-nonce");
 		expect((script as ScriptElement).props.dangerouslySetInnerHTML?.__html).toContain('"dark"');
-	});
-
-	test("preserves scriptProps.nonce when nonce prop is omitted", () => {
-		render(
-			<ClientNextThemeProvider scriptProps={{ nonce: "from-script-props" }}>
-				<span>content</span>
-			</ClientNextThemeProvider>,
-		);
-
-		const script = insertedHtml[0] as ScriptElement;
-		expect(script.props.nonce).toBe("from-script-props");
+		expect(callback?.()).toBeNull();
 	});
 });

--- a/packages/themes/src/__tests__/get-theme.test.ts
+++ b/packages/themes/src/__tests__/get-theme.test.ts
@@ -2,12 +2,18 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 import { getTheme } from "../get-theme.js";
 
 let nextCookieValue: string | undefined;
+let nextCookieReads = 0;
 
 mock.module("next/headers", () => ({
-	cookies: async () => ({
-		get: (_key: string) =>
-			nextCookieValue === undefined ? undefined : { name: "theme", value: nextCookieValue },
-	}),
+	cookies: async () => {
+		nextCookieReads += 1;
+		return {
+			get: (_key: string) =>
+				nextCookieValue === undefined
+					? undefined
+					: { name: "theme", value: nextCookieValue },
+		};
+	},
 }));
 
 function makeRequest(cookieHeader: string): Request {
@@ -18,6 +24,7 @@ function makeRequest(cookieHeader: string): Request {
 
 beforeEach(() => {
 	nextCookieValue = undefined;
+	nextCookieReads = 0;
 });
 
 describe("getTheme - sync (Request)", () => {
@@ -107,51 +114,31 @@ describe("getTheme - async (no Request)", () => {
 	});
 });
 
-describe("Next ThemeProvider cookie validation", () => {
-	test("passes a valid stored theme as initialTheme", async () => {
+describe("Next ThemeProvider App Shell behavior", () => {
+	test("leaves cookie reads to the pre-hydration script", async () => {
 		nextCookieValue = "dark";
 		const { ThemeProvider } = await import("../providers/next-provider.js");
-		const element = await ThemeProvider({
+		const element = ThemeProvider({
 			children: null,
 			storage: "cookie",
 			themes: ["light", "dark"],
 		});
 
+		expect(nextCookieReads).toBe(0);
+		expect((element.props as { storage?: string }).storage).toBe("cookie");
+		expect((element.props as { initialTheme?: string }).initialTheme).toBeUndefined();
+	});
+
+	test("preserves an explicit initialTheme without reading request data", async () => {
+		const { ThemeProvider } = await import("../providers/next-provider.js");
+		const element = ThemeProvider({
+			children: null,
+			storage: "cookie",
+			themes: ["light", "dark"],
+			initialTheme: "dark",
+		});
+
+		expect(nextCookieReads).toBe(0);
 		expect((element.props as { initialTheme?: string }).initialTheme).toBe("dark");
-	});
-
-	test("ignores stored values outside the configured themes", async () => {
-		const { ThemeProvider } = await import("../providers/next-provider.js");
-
-		for (const stored of ["unknown", "high%2Dcontrast", "%E0%A4%A"]) {
-			nextCookieValue = stored;
-			const element = await ThemeProvider({
-				children: null,
-				storage: "cookie",
-				themes: ["light", "dark"],
-			});
-
-			expect((element.props as { initialTheme?: string }).initialTheme).toBeUndefined();
-		}
-	});
-
-	test("honors enableSystem when validating the stored theme", async () => {
-		const { ThemeProvider } = await import("../providers/next-provider.js");
-		nextCookieValue = "system";
-
-		const enabled = await ThemeProvider({
-			children: null,
-			storage: "cookie",
-			themes: ["light", "dark"],
-		});
-		const disabled = await ThemeProvider({
-			children: null,
-			storage: "cookie",
-			themes: ["light", "dark"],
-			enableSystem: false,
-		});
-
-		expect((enabled.props as { initialTheme?: string }).initialTheme).toBe("system");
-		expect((disabled.props as { initialTheme?: string }).initialTheme).toBeUndefined();
 	});
 });

--- a/packages/themes/src/providers/next-provider.tsx
+++ b/packages/themes/src/providers/next-provider.tsx
@@ -1,30 +1,9 @@
-import { cookies } from "next/headers";
 import type { ReactElement } from "react";
-import { isThemeSelection } from "../core/theme-validation.js";
 import type { DefaultTheme, ThemeProviderProps } from "../core/types.js";
 import { ClientNextThemeProvider } from "./client-next-provider.js";
 
-export async function ThemeProvider<Themes extends string = DefaultTheme>(
+export function ThemeProvider<Themes extends string = DefaultTheme>(
 	props: ThemeProviderProps<Themes>,
-): Promise<ReactElement> {
-	let serverTheme: string | undefined;
-
-	if (props.storage === "cookie" || props.storage === "hybrid") {
-		try {
-			const cookieStore = await cookies();
-			const stored = cookieStore.get(props.storageKey ?? "theme")?.value;
-			if (stored && isThemeSelection(stored, props.themes, props.enableSystem ?? true)) {
-				serverTheme = stored;
-			}
-		} catch {
-			// Static generation or out-of-request context
-		}
-	}
-
-	const initialTheme = props.initialTheme ?? (serverTheme as Themes | undefined);
-	return initialTheme === undefined ? (
-		<ClientNextThemeProvider {...props} />
-	) : (
-		<ClientNextThemeProvider {...props} initialTheme={initialTheme} />
-	);
+): ReactElement {
+	return <ClientNextThemeProvider {...props} />;
 }


### PR DESCRIPTION
## Stack

PR 6 of 9. Depends on `split/05-use-effect-event-compat`. This cumulative upstream PR targets `main`; review the commits after `split/05-use-effect-event-compat` for this PRs isolated scope.

## Summary

- Remove the implicit `cookies()` call from the Next.js `ThemeProvider`.
- Keep the provider synchronous and stable inside App Router shells and Instant Navigation boundaries.
- Leave explicit server cookie reads to `getTheme` or the pre-hydration bootstrap.
- Add a Next.js 16.3 preview fixture with tenant layouts, prefetched navigation, metadata, and Playwright coverage.
- Update migration and provider documentation for the new server-theme flow.

## Breaking changes

- `ThemeProvider` no longer reads the request cookie implicitly. Apps that relied on this behavior must call `getTheme` explicitly and pass `initialTheme`, or rely on the bootstrap script for pre-hydration application.
- `ThemeProvider` is now synchronous rather than returning a promise-backed Server Component result.

## Verification

- Next.js 16.3 fixture type-check passed.
- Production fixture build passed.
- Instant Navigation Playwright test passed.