### PR TITLE
test(themes): strengthen bootstrap and runtime parity

### DIFF
--- a/apps/docs/content/docs/api/theme-provider.mdx
+++ b/apps/docs/content/docs/api/theme-provider.mdx
@@ -9,8 +9,9 @@ Two variants are available depending on your framework:
 
 | Import | Mechanism | Use when |
 |--------|-----------|----------|
-| `@wrksz/themes/next` | `useServerInsertedHTML` | Next.js 16+ (no React 19 warning) |
-| `@wrksz/themes` | inline `<script>` in RSC | Other frameworks |
+| `@wrksz/themes/next` | `useServerInsertedHTML` for `<html>`; synchronous adjacent script for later targets | Next.js 16+ (no React 19 warning) |
+| `@wrksz/themes` | Client-only provider | Nested scopes and client-rendered React |
+| `@wrksz/themes/script` | Server-rendered bootstrap script | Other SSR frameworks |
 
 ```tsx title="app/layout.tsx (Next.js)"
 import { ThemeProvider } from "@wrksz/themes/next";

--- a/apps/docs/content/docs/api/theme-provider.mdx
+++ b/apps/docs/content/docs/api/theme-provider.mdx
@@ -61,7 +61,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
 | `themes` | `readonly string[]` | `["light", "dark"]` | Available themes. Use `as const` to preserve custom theme unions in TypeScript |
 | `defaultTheme` | `string` | `"system"` | Theme used when no preference is stored |
 | `forcedTheme` | `string` | - | Force a specific theme, ignoring user preference |
-| `initialTheme` | `string` | - | Server-provided theme that overrides storage on mount. User can still call `setTheme` to change it |
+| `initialTheme` | `string` | - | Server-provided theme that overrides storage on mount. User can still call `setTheme` to change it. Mount init is sticky: later prop changes to `storageKey` / `initialTheme` do not re-run initialization (`forcedTheme` still updates via overlay). |
 | `enableSystem` | `boolean` | `true` | Detect system preference via `prefers-color-scheme` |
 | `enableColorScheme` | `boolean` | `true` | Set native `color-scheme` CSS property |
 | `attribute` | `"class" \| "data-*" \| ("class" \| "data-*")[]` | `"class"` | HTML attribute(s) to set on the target element |

--- a/apps/docs/content/docs/examples/scoped-theming.mdx
+++ b/apps/docs/content/docs/examples/scoped-theming.mdx
@@ -7,6 +7,8 @@ By default `ThemeProvider` applies the theme to `<html>`. Use the `target` prop 
 
 Use `ClientThemeProvider` for nested providers - the inline anti-flash script is only needed in the root layout. `ClientThemeProvider` handles state without rendering an extra script.
 
+For a server-rendered root scope that targets `"body"` or a descendant selector, use `ThemeProvider` from `@wrksz/themes/next`. It emits the parser-blocking bootstrap immediately after the provider subtree so the target already exists when the script runs, while the default `"html"` target continues to use `useServerInsertedHTML`.
+
 ## Setup
 
 ```tsx title="app/landing/layout.tsx"

--- a/apps/next-16-3/src/app/[tenant]/layout.tsx
+++ b/apps/next-16-3/src/app/[tenant]/layout.tsx
@@ -34,6 +34,22 @@ export default function TenantLayout({ children }: { children: ReactNode }) {
 					</header>
 					{children}
 				</ThemeProvider>
+				<ThemeProvider
+					target="body"
+					forcedTheme="dark"
+					storage="none"
+					scriptProps={{ "data-body-theme-bootstrap": "true" }}
+				>
+					<span hidden data-testid="body-theme-target" />
+				</ThemeProvider>
+				<ThemeProvider
+					target="#scoped-theme-target"
+					forcedTheme="dark"
+					storage="none"
+					scriptProps={{ "data-scoped-theme-bootstrap": "true" }}
+				>
+					<div id="scoped-theme-target" data-testid="scoped-theme-target" />
+				</ThemeProvider>
 			</body>
 		</html>
 	);

--- a/apps/next-16-3/tests/instant-navigation.spec.ts
+++ b/apps/next-16-3/tests/instant-navigation.spec.ts
@@ -24,6 +24,9 @@ test("keeps the current theme across prefetched shells and root params", async (
 	expect(documentHtml.indexOf("data-theme-bootstrap")).toBeLessThan(
 		documentHtml.indexOf("<body"),
 	);
+	expect(documentHtml.indexOf("scoped-theme-target")).toBeLessThan(
+		documentHtml.indexOf("data-scoped-theme-bootstrap"),
+	);
 	expect(documentHtml).toContain("document.cookie");
 
 	await page.goto("/alpha");
@@ -35,6 +38,12 @@ test("keeps the current theme across prefetched shells and root params", async (
 	expect(initialScriptCount).toBeGreaterThan(0);
 	const bootstrapSources = await bootstrapScripts.allTextContents();
 	expect(new Set(bootstrapSources).size).toBe(1);
+	await expect(page.locator("body")).toHaveClass(/dark/);
+	await expect(page.getByTestId("scoped-theme-target")).toHaveClass(/dark/);
+	const bodyBootstrapScripts = page.locator("script[data-body-theme-bootstrap]");
+	const scopedBootstrapScripts = page.locator("script[data-scoped-theme-bootstrap]");
+	await expect(bodyBootstrapScripts).toHaveCount(1);
+	await expect(scopedBootstrapScripts).toHaveCount(1);
 
 	await page.evaluate(() => {
 		Object.defineProperty(window, "__spaMarker", { value: true, writable: true });
@@ -51,12 +60,16 @@ test("keeps the current theme across prefetched shells and root params", async (
 	await expect(page.getByRole("heading", { name: "alpha about" })).toBeVisible();
 	await expect(page.locator("html")).toHaveClass(/light/);
 	await expect(bootstrapScripts).toHaveCount(initialScriptCount);
+	await expect(bodyBootstrapScripts).toHaveCount(1);
+	await expect(scopedBootstrapScripts).toHaveCount(1);
 
 	await page.getByRole("link", { name: "Switch tenant" }).click();
 	await expect(page).toHaveURL("/beta/about");
 	await expect(page.getByRole("heading", { name: "beta about" })).toBeVisible();
 	await expect(page.getByTestId("root-param").filter({ visible: true })).toHaveText("beta");
 	await expect(page.locator("html")).toHaveClass(/light/);
+	await expect(bodyBootstrapScripts).toHaveCount(1);
+	await expect(scopedBootstrapScripts).toHaveCount(1);
 
 	await page.goBack();
 	await expect(page).toHaveURL("/alpha/about");

--- a/packages/themes/benchmarks/baseline.json
+++ b/packages/themes/benchmarks/baseline.json
@@ -1,52 +1,52 @@
 [
 	{
 		"name": "use-theme",
-		"bytes": 404,
-		"gzipBytes": 280
+		"bytes": 456,
+		"gzipBytes": 300
 	},
 	{
 		"name": "use-theme-subpath",
-		"bytes": 411,
-		"gzipBytes": 286
+		"bytes": 463,
+		"gzipBytes": 305
 	},
 	{
 		"name": "use-theme-value",
-		"bytes": 437,
-		"gzipBytes": 289
+		"bytes": 587,
+		"gzipBytes": 350
 	},
 	{
 		"name": "use-theme-value-subpath",
-		"bytes": 444,
-		"gzipBytes": 294
+		"bytes": 594,
+		"gzipBytes": 367
 	},
 	{
 		"name": "themed-image",
-		"bytes": 625,
-		"gzipBytes": 411
+		"bytes": 699,
+		"gzipBytes": 435
 	},
 	{
 		"name": "themed-image-subpath",
-		"bytes": 632,
-		"gzipBytes": 420
+		"bytes": 706,
+		"gzipBytes": 453
 	},
 	{
 		"name": "next-provider",
-		"bytes": 9571,
-		"gzipBytes": 3607
+		"bytes": 10112,
+		"gzipBytes": 3794
 	},
 	{
 		"name": "script",
-		"bytes": 3248,
-		"gzipBytes": 1465
+		"bytes": 3065,
+		"gzipBytes": 1432
 	},
 	{
 		"name": "client-provider",
-		"bytes": 8643,
-		"gzipBytes": 3517
+		"bytes": 6598,
+		"gzipBytes": 2746
 	},
 	{
 		"name": "generated-script",
-		"bytes": 1950,
-		"gzipBytes": 950
+		"bytes": 1772,
+		"gzipBytes": 927
 	}
 ]

--- a/packages/themes/benchmarks/baseline.json
+++ b/packages/themes/benchmarks/baseline.json
@@ -33,5 +33,20 @@
 		"name": "next-provider",
 		"bytes": 9571,
 		"gzipBytes": 3607
+	},
+	{
+		"name": "script",
+		"bytes": 3248,
+		"gzipBytes": 1465
+	},
+	{
+		"name": "client-provider",
+		"bytes": 8643,
+		"gzipBytes": 3517
+	},
+	{
+		"name": "generated-script",
+		"bytes": 1950,
+		"gzipBytes": 950
 	}
 ]

--- a/packages/themes/benchmarks/bundle-size-thresholds.json
+++ b/packages/themes/benchmarks/bundle-size-thresholds.json
@@ -36,7 +36,7 @@
 		"maxDeltaGzipBytes": 120
 	},
 	"next-provider": {
-		"maxBytes": 10000,
+		"maxBytes": 10500,
 		"maxGzipBytes": 4000,
 		"maxDeltaBytes": 500,
 		"maxDeltaGzipBytes": 250

--- a/packages/themes/benchmarks/bundle-size-thresholds.json
+++ b/packages/themes/benchmarks/bundle-size-thresholds.json
@@ -40,5 +40,23 @@
 		"maxGzipBytes": 4000,
 		"maxDeltaBytes": 500,
 		"maxDeltaGzipBytes": 250
+	},
+	"script": {
+		"maxBytes": 3600,
+		"maxGzipBytes": 1650,
+		"maxDeltaBytes": 250,
+		"maxDeltaGzipBytes": 150
+	},
+	"client-provider": {
+		"maxBytes": 9500,
+		"maxGzipBytes": 3900,
+		"maxDeltaBytes": 500,
+		"maxDeltaGzipBytes": 250
+	},
+	"generated-script": {
+		"maxBytes": 2200,
+		"maxGzipBytes": 1100,
+		"maxDeltaBytes": 200,
+		"maxDeltaGzipBytes": 120
 	}
 }

--- a/packages/themes/benchmarks/entries/client-provider.tsx
+++ b/packages/themes/benchmarks/entries/client-provider.tsx
@@ -1,0 +1,6 @@
+import { ClientThemeProvider } from "@wrksz/themes/client/provider";
+import type { ReactElement, ReactNode } from "react";
+
+export function ClientProviderFixture({ children }: { children: ReactNode }): ReactElement {
+	return <ClientThemeProvider defaultTheme="dark">{children}</ClientThemeProvider>;
+}

--- a/packages/themes/benchmarks/entries/script.tsx
+++ b/packages/themes/benchmarks/entries/script.tsx
@@ -1,0 +1,6 @@
+import { ThemeScript } from "@wrksz/themes/script";
+import type { ReactElement } from "react";
+
+export const scriptFixture: ReactElement = (
+	<ThemeScript defaultTheme="dark" enableSystem={false} />
+);

--- a/packages/themes/build-entries.ts
+++ b/packages/themes/build-entries.ts
@@ -1,0 +1,24 @@
+export const PUBLIC_BUILD_ENTRIES: readonly string[] = [
+	"src/index.ts",
+	"src/client.ts",
+	"src/client/use-theme.ts",
+	"src/client/use-theme-value.ts",
+	"src/client/use-theme-effect.ts",
+	"src/client/use-hydrated.ts",
+	"src/client/themed-image.ts",
+	"src/client/provider.ts",
+	"src/client/create-themes.ts",
+	"src/next.ts",
+	"src/script.ts",
+];
+
+export const INTERNAL_RUNTIME_BUILD_ENTRIES: readonly string[] = [
+	"src/providers/client-next-provider.tsx",
+];
+
+export const RUNTIME_BUILD_ENTRIES: readonly string[] = [
+	...PUBLIC_BUILD_ENTRIES,
+	...INTERNAL_RUNTIME_BUILD_ENTRIES,
+];
+
+export const DECLARATION_BUILD_ENTRIES: readonly string[] = PUBLIC_BUILD_ENTRIES;

--- a/packages/themes/bunup.config.ts
+++ b/packages/themes/bunup.config.ts
@@ -1,37 +1,13 @@
 import { defineConfig } from "bunup";
+import { DECLARATION_BUILD_ENTRIES, RUNTIME_BUILD_ENTRIES } from "./build-entries.js";
 
 export default defineConfig({
-	entry: [
-		"src/index.ts",
-		"src/client.ts",
-		"src/client/use-theme.ts",
-		"src/client/use-theme-value.ts",
-		"src/client/use-theme-effect.ts",
-		"src/client/use-hydrated.ts",
-		"src/client/themed-image.ts",
-		"src/client/provider.ts",
-		"src/client/create-themes.ts",
-		"src/next.ts",
-		"src/script.ts",
-		"src/providers/client-next-provider.tsx",
-	],
+	entry: RUNTIME_BUILD_ENTRIES,
 	format: ["esm"],
 	target: "browser",
 	sourceBase: "./src",
 	dts: {
-		entry: [
-			"src/index.ts",
-			"src/client.ts",
-			"src/client/use-theme.ts",
-			"src/client/use-theme-value.ts",
-			"src/client/use-theme-effect.ts",
-			"src/client/use-hydrated.ts",
-			"src/client/themed-image.ts",
-			"src/client/provider.ts",
-			"src/client/create-themes.ts",
-			"src/next.ts",
-			"src/script.ts",
-		],
+		entry: DECLARATION_BUILD_ENTRIES,
 		splitting: true,
 	},
 	external: ["next/headers"],

--- a/packages/themes/scripts/bundle-size.ts
+++ b/packages/themes/scripts/bundle-size.ts
@@ -2,6 +2,7 @@ import { Buffer } from "node:buffer";
 import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { join, relative, resolve } from "node:path";
 import { gzipSync } from "node:zlib";
+import { getScript } from "../src/core/script.js";
 
 export type BundleReport = {
 	name: string;
@@ -46,7 +47,11 @@ const cases: BundleCase[] = [
 	{ name: "themed-image", entry: "entries/themed-image.tsx" },
 	{ name: "themed-image-subpath", entry: "entries/themed-image-subpath.tsx" },
 	{ name: "next-provider", entry: "entries/next-provider.tsx" },
+	{ name: "script", entry: "entries/script.tsx" },
+	{ name: "client-provider", entry: "entries/client-provider.tsx" },
 ];
+
+export const GENERATED_SCRIPT_REPORT_NAME = "generated-script";
 
 /**
  * Literal dynamic-import edges so dead-code analysis can see these fixtures as
@@ -62,7 +67,13 @@ export function bundleEntryModuleLoaders(): ReadonlyArray<() => Promise<unknown>
 		() => import("../benchmarks/entries/themed-image.tsx"),
 		() => import("../benchmarks/entries/themed-image-subpath.tsx"),
 		() => import("../benchmarks/entries/next-provider.tsx"),
+		() => import("../benchmarks/entries/script.tsx"),
+		() => import("../benchmarks/entries/client-provider.tsx"),
 	];
+}
+
+export function bundleReportNames(): readonly string[] {
+	return [...cases.map(({ name }) => name), GENERATED_SCRIPT_REPORT_NAME];
 }
 
 const externals = ["react", "react-dom", "react/jsx-runtime", "next/headers", "next/navigation"];
@@ -227,6 +238,36 @@ async function bundleCase(bundleCase: BundleCase): Promise<BundleReport> {
 	};
 }
 
+export function measureText(name: string, text: string): BundleReport {
+	return {
+		name,
+		bytes: Buffer.byteLength(text),
+		gzipBytes: gzipSync(text, { level: 9 }).byteLength,
+	};
+}
+
+async function generatedScriptCase(): Promise<BundleReport> {
+	const source = getScript({
+		storageKey: "theme",
+		attribute: ["class", "data-theme"],
+		defaultTheme: "system",
+		enableSystem: true,
+		enableColorScheme: true,
+		forcedTheme: undefined,
+		themes: ["light", "dark"],
+		value: { dark: "dark dark-palette" },
+		target: "html",
+		storage: "hybrid",
+		themeColors: { light: "#fff", dark: "#000" },
+		initialTheme: undefined,
+		disableTransitionOnChange: true,
+		followSystem: false,
+	});
+	await mkdir(outputDir, { recursive: true });
+	await Bun.write(join(outputDir, `${GENERATED_SCRIPT_REPORT_NAME}.js`), source);
+	return measureText(GENERATED_SCRIPT_REPORT_NAME, source);
+}
+
 function printReport(reports: BundleReport[], thresholds: BundleThresholds): void {
 	const rows = reports.map((report) => {
 		const threshold = thresholds[report.name];
@@ -292,6 +333,7 @@ async function main(): Promise<void> {
 	for (const currentCase of cases) {
 		reports.push(await bundleCase(currentCase));
 	}
+	reports.push(await generatedScriptCase());
 
 	if (updateBaseline) {
 		await writeBaseline(reports);

--- a/packages/themes/src/__tests__/bootstrap-runtime-parity.test.tsx
+++ b/packages/themes/src/__tests__/bootstrap-runtime-parity.test.tsx
@@ -1,0 +1,289 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { cleanup, render } from "@testing-library/react";
+import { applyThemeToDom } from "../core/client-dom.js";
+import { getScript } from "../core/script.js";
+import { resolveDefaultTheme } from "../core/theme-validation.js";
+import type { Attribute, ThemeProviderProps } from "../core/types.js";
+import { ClientThemeProvider } from "../providers/client-provider.js";
+
+type DomSnapshot = {
+	classes: string[];
+	dataTheme: string | null;
+	colorScheme: string;
+	themeColor: string | null;
+	transitionStyle: string | null;
+};
+
+type ParityCase = {
+	name: string;
+	themes: string[];
+	attribute: Attribute | readonly Attribute[];
+	enableSystem: boolean;
+	defaultTheme?: string;
+	storedTheme?: string;
+	initialTheme?: string;
+	forcedTheme?: string;
+	value?: Record<string, string>;
+	themeColor?: Record<string, string>;
+	enableColorScheme: boolean;
+	disableTransitionOnChange: boolean | string;
+	prefersDark: boolean;
+	expected: DomSnapshot;
+};
+
+const noTransition = false;
+
+const cases: ParityCase[] = [
+	{
+		name: "mapped multi-class storage with complete DOM side effects",
+		themes: ["light", "dark"],
+		attribute: ["class", "data-theme"],
+		enableSystem: false,
+		storedTheme: "dark",
+		value: { dark: "dark dark-palette" },
+		themeColor: { dark: "#000" },
+		enableColorScheme: true,
+		disableTransitionOnChange: "background-color 0s",
+		prefersDark: false,
+		expected: {
+			classes: ["dark", "dark-palette"],
+			dataTheme: "dark dark-palette",
+			colorScheme: "dark",
+			themeColor: "#000",
+			transitionStyle: "*,*::before,*::after{transition:background-color 0s!important}",
+		},
+	},
+	{
+		name: "absent storage resolves the system preference",
+		themes: ["light", "dark"],
+		attribute: ["class", "data-theme"],
+		enableSystem: true,
+		themeColor: { dark: "#001" },
+		enableColorScheme: true,
+		disableTransitionOnChange: true,
+		prefersDark: true,
+		expected: {
+			classes: ["dark"],
+			dataTheme: "dark",
+			colorScheme: "dark",
+			themeColor: "#001",
+			transitionStyle: "*,*::before,*::after{transition:none!important}",
+		},
+	},
+	{
+		name: "invalid storage and default fall back to the first custom theme",
+		themes: ["paper", "midnight"],
+		attribute: "data-theme",
+		enableSystem: false,
+		storedTheme: "invalid",
+		defaultTheme: "invalid",
+		enableColorScheme: true,
+		disableTransitionOnChange: noTransition,
+		prefersDark: false,
+		expected: {
+			classes: [],
+			dataTheme: "paper",
+			colorScheme: "",
+			themeColor: null,
+			transitionStyle: null,
+		},
+	},
+	{
+		name: "forced theme wins over initial and stored selections",
+		themes: ["light", "dark"],
+		attribute: "class",
+		enableSystem: false,
+		storedTheme: "light",
+		initialTheme: "light",
+		forcedTheme: "dark",
+		enableColorScheme: true,
+		disableTransitionOnChange: noTransition,
+		prefersDark: false,
+		expected: {
+			classes: ["dark"],
+			dataTheme: null,
+			colorScheme: "dark",
+			themeColor: null,
+			transitionStyle: null,
+		},
+	},
+	{
+		name: "absent storage and disabled system use the first theme",
+		themes: ["paper", "midnight"],
+		attribute: "class",
+		enableSystem: false,
+		enableColorScheme: false,
+		disableTransitionOnChange: noTransition,
+		prefersDark: true,
+		expected: {
+			classes: ["paper"],
+			dataTheme: null,
+			colorScheme: "",
+			themeColor: null,
+			transitionStyle: null,
+		},
+	},
+];
+
+function resetDom(parityCase?: ParityCase): void {
+	cleanup();
+	localStorage.clear();
+	document.documentElement.className = "";
+	document.documentElement.removeAttribute("data-theme");
+	document.documentElement.style.colorScheme = "";
+	for (const element of Array.from(
+		document.querySelectorAll('meta[name="theme-color"], style'),
+	)) {
+		element.remove();
+	}
+	if (parityCase?.storedTheme !== undefined) {
+		localStorage.setItem("theme", parityCase.storedTheme);
+	}
+}
+
+function captureDom(run: () => void): DomSnapshot {
+	let transitionStyle: string | null = null;
+	const appendChild = document.head.appendChild.bind(document.head);
+	document.head.appendChild = <NodeType extends Node>(node: NodeType): NodeType => {
+		if ((node as unknown as Element).tagName === "STYLE") {
+			transitionStyle = (node as unknown as Element).textContent;
+		}
+		return appendChild(node) as NodeType;
+	};
+
+	try {
+		run();
+	} finally {
+		document.head.appendChild = appendChild;
+	}
+
+	return {
+		classes: Array.from(document.documentElement.classList).sort(),
+		dataTheme: document.documentElement.getAttribute("data-theme"),
+		colorScheme: document.documentElement.style.colorScheme,
+		themeColor:
+			document
+				.querySelector<HTMLMetaElement>('meta[name="theme-color"]')
+				?.getAttribute("content") ?? null,
+		transitionStyle,
+	};
+}
+
+function isValidSelection(selection: string, parityCase: ParityCase): boolean {
+	return selection === "system" ? parityCase.enableSystem : parityCase.themes.includes(selection);
+}
+
+function resolveCase(parityCase: ParityCase): string {
+	const defaultTheme = resolveDefaultTheme(
+		parityCase.themes,
+		parityCase.enableSystem,
+		parityCase.defaultTheme,
+	);
+	const selection =
+		(parityCase.forcedTheme && parityCase.themes.includes(parityCase.forcedTheme)
+			? parityCase.forcedTheme
+			: undefined) ??
+		(parityCase.initialTheme && isValidSelection(parityCase.initialTheme, parityCase)
+			? parityCase.initialTheme
+			: undefined) ??
+		(parityCase.storedTheme && isValidSelection(parityCase.storedTheme, parityCase)
+			? parityCase.storedTheme
+			: defaultTheme);
+	const systemTheme = parityCase.prefersDark ? "dark" : "light";
+	return selection === "system" ? systemTheme : selection;
+}
+
+function getProviderProps(parityCase: ParityCase): Omit<ThemeProviderProps<string>, "children"> {
+	return {
+		themes: parityCase.themes,
+		attribute: parityCase.attribute,
+		enableSystem: parityCase.enableSystem,
+		enableColorScheme: parityCase.enableColorScheme,
+		disableTransitionOnChange: parityCase.disableTransitionOnChange,
+		storage: "localStorage",
+		...(parityCase.defaultTheme === undefined ? {} : { defaultTheme: parityCase.defaultTheme }),
+		...(parityCase.forcedTheme === undefined ? {} : { forcedTheme: parityCase.forcedTheme }),
+		...(parityCase.initialTheme === undefined ? {} : { initialTheme: parityCase.initialTheme }),
+		...(parityCase.value === undefined ? {} : { value: parityCase.value }),
+		...(parityCase.themeColor === undefined ? {} : { themeColor: parityCase.themeColor }),
+	};
+}
+
+beforeEach(() => {
+	// Flush transition-disable style cleanup synchronously so later suites are not
+	// hit by happy-dom removeChild errors from pending requestAnimationFrame work.
+	const flushFrame = ((callback: FrameRequestCallback) => {
+		callback(0);
+		return 0;
+	}) as typeof requestAnimationFrame;
+	globalThis.requestAnimationFrame = flushFrame;
+	window.requestAnimationFrame = flushFrame;
+	resetDom();
+});
+
+afterEach(() => {
+	resetDom();
+});
+
+describe("bootstrap/runtime/provider parity", () => {
+	for (const parityCase of cases) {
+		test(parityCase.name, () => {
+			window.matchMedia = () => ({ matches: parityCase.prefersDark }) as MediaQueryList;
+			const defaultTheme = resolveDefaultTheme(
+				parityCase.themes,
+				parityCase.enableSystem,
+				parityCase.defaultTheme,
+			);
+
+			resetDom(parityCase);
+			const scriptSnapshot = captureDom(() => {
+				// biome-ignore lint/security/noGlobalEval: executes the generated bootstrap in the test DOM
+				eval(
+					getScript({
+						storageKey: "theme",
+						attribute: parityCase.attribute,
+						defaultTheme,
+						enableSystem: parityCase.enableSystem,
+						enableColorScheme: parityCase.enableColorScheme,
+						forcedTheme: parityCase.forcedTheme,
+						themes: parityCase.themes,
+						value: parityCase.value,
+						target: "html",
+						storage: "localStorage",
+						themeColors: parityCase.themeColor,
+						initialTheme: parityCase.initialTheme,
+						disableTransitionOnChange: parityCase.disableTransitionOnChange,
+						followSystem: false,
+					}),
+				);
+			});
+
+			resetDom(parityCase);
+			const directDomSnapshot = captureDom(() => {
+				applyThemeToDom({
+					resolved: resolveCase(parityCase),
+					attribute: parityCase.attribute,
+					themes: parityCase.themes,
+					valueMap: parityCase.value,
+					target: "html",
+					disableTransitionOnChange: parityCase.disableTransitionOnChange,
+					enableColorScheme: parityCase.enableColorScheme,
+					themeColor: parityCase.themeColor,
+				});
+			});
+
+			resetDom(parityCase);
+			const providerSnapshot = captureDom(() => {
+				render(
+					<ClientThemeProvider<string> {...getProviderProps(parityCase)}>
+						<span>content</span>
+					</ClientThemeProvider>,
+				);
+			});
+
+			expect(scriptSnapshot).toEqual(parityCase.expected);
+			expect(directDomSnapshot).toEqual(parityCase.expected);
+			expect(providerSnapshot).toEqual(parityCase.expected);
+		});
+	}
+});

--- a/packages/themes/src/__tests__/bundle-size-script.test.ts
+++ b/packages/themes/src/__tests__/bundle-size-script.test.ts
@@ -2,14 +2,31 @@ import { describe, expect, test } from "bun:test";
 import {
 	type BundleReport,
 	type BundleThresholds,
+	bundleEntryModuleLoaders,
+	bundleReportNames,
 	compareReports,
 	compareWithBaseline,
 	formatBytes,
 	formatDeltaBytes,
 	formatPercent,
+	GENERATED_SCRIPT_REPORT_NAME,
+	measureText,
 } from "../../scripts/bundle-size.ts";
 
 describe("bundle-size script helpers", () => {
+	test("keeps every benchmark fixture statically reachable", () => {
+		expect(bundleEntryModuleLoaders()).toHaveLength(9);
+		expect(bundleReportNames()).toContain(GENERATED_SCRIPT_REPORT_NAME);
+		expect(bundleReportNames()).not.toContain("get-script");
+	});
+
+	test("measures generated text rather than generator bundle code", () => {
+		const report = measureText(GENERATED_SCRIPT_REPORT_NAME, "abc");
+		expect(report.name).toBe("generated-script");
+		expect(report.bytes).toBe(3);
+		expect(report.gzipBytes).toBeGreaterThan(0);
+	});
+
 	test("formatBytes formats bytes and kibibytes", () => {
 		expect(formatBytes(512)).toBe("512 B");
 		expect(formatBytes(1536)).toBe("1.50 KiB");

--- a/packages/themes/src/__tests__/client-next-provider.test.tsx
+++ b/packages/themes/src/__tests__/client-next-provider.test.tsx
@@ -56,4 +56,55 @@ describe("ClientNextThemeProvider", () => {
 		expect(isValidElement(script)).toBe(true);
 		expect((script as ScriptElement).props.nonce).toBe("from-script-props");
 	});
+
+	test("normalizes defaults against custom themes", () => {
+		render(
+			<ClientNextThemeProvider
+				themes={["paper", "midnight"]}
+				enableSystem={false}
+				defaultTheme={"invalid" as "paper"}
+			>
+				<span>content</span>
+			</ClientNextThemeProvider>,
+		);
+
+		const script = insertedHtmlCallbacks[0]?.() as ScriptElement;
+		expect(script.props.dangerouslySetInnerHTML?.__html).toContain('"paper",false');
+	});
+
+	test("rejects system default when system mode is disabled", () => {
+		render(
+			<ClientNextThemeProvider
+				themes={["paper", "midnight"]}
+				enableSystem={false}
+				defaultTheme="system"
+			>
+				<span>content</span>
+			</ClientNextThemeProvider>,
+		);
+
+		const script = insertedHtmlCallbacks[0]?.() as ScriptElement;
+		expect(script.props.dangerouslySetInnerHTML?.__html).toContain('"paper",false');
+	});
+
+	test("renders non-html target scripts after the provider subtree", () => {
+		const view = render(
+			<ClientNextThemeProvider
+				target="body"
+				nonce="body-nonce"
+				scriptProps={{ "data-theme-bootstrap": "body" }}
+			>
+				<span data-testid="target-content">content</span>
+			</ClientNextThemeProvider>,
+		);
+
+		expect(insertedHtmlCallbacks[0]?.()).toBeNull();
+		const content = view.getByTestId("target-content");
+		const script = view.container.querySelector<HTMLScriptElement>(
+			'script[data-theme-bootstrap="body"]',
+		);
+		expect(script).not.toBeNull();
+		expect(script?.getAttribute("nonce")).toBe("body-nonce");
+		expect(content.compareDocumentPosition(script as Node) & 4).toBe(4);
+	});
 });

--- a/packages/themes/src/__tests__/client-provider.test.tsx
+++ b/packages/themes/src/__tests__/client-provider.test.tsx
@@ -439,6 +439,83 @@ describe("ClientThemeProvider - cross-tab storage sync", () => {
 });
 
 describe("ClientThemeProvider - runtime hardening", () => {
+	test("preserves manual selection across configuration object rerenders", () => {
+		const view = render(
+			<ClientThemeProvider
+				cookieOptions={{ maxAge: 60 }}
+				value={{ dark: "dark-one" }}
+				themeColor={{ dark: "#000" }}
+			>
+				<ThemeConsumer />
+			</ClientThemeProvider>,
+		);
+		act(() => fireEvent.click(screen.getByTestId("btn-dark")));
+
+		view.rerender(
+			<ClientThemeProvider
+				cookieOptions={{ maxAge: 120 }}
+				value={{ dark: "dark-two" }}
+				themeColor={{ dark: "#111" }}
+			>
+				<ThemeConsumer />
+			</ClientThemeProvider>,
+		);
+
+		expect(screen.getByTestId("theme").textContent).toBe("dark");
+		expect(document.documentElement.classList.contains("dark-two")).toBe(true);
+		expect(document.querySelector('meta[name="theme-color"]')?.getAttribute("content")).toBe(
+			"#111",
+		);
+	});
+
+	test("keeps storage=none selections in memory across rerenders", () => {
+		const view = render(
+			<ClientThemeProvider storage="none">
+				<ThemeConsumer />
+			</ClientThemeProvider>,
+		);
+		act(() => fireEvent.click(screen.getByTestId("btn-dark")));
+		view.rerender(
+			<ClientThemeProvider storage="none" cookieOptions={{ maxAge: 120 }}>
+				<ThemeConsumer />
+			</ClientThemeProvider>,
+		);
+		expect(screen.getByTestId("theme").textContent).toBe("dark");
+	});
+
+	test("writes initialTheme only during initialization", () => {
+		const view = render(
+			<ClientThemeProvider initialTheme="dark">
+				<ThemeConsumer />
+			</ClientThemeProvider>,
+		);
+		act(() => fireEvent.click(screen.getByTestId("btn-light")));
+		view.rerender(
+			<ClientThemeProvider initialTheme="dark" cookieOptions={{ maxAge: 120 }}>
+				<ThemeConsumer />
+			</ClientThemeProvider>,
+		);
+		expect(screen.getByTestId("theme").textContent).toBe("light");
+		expect(localStorage.getItem("theme")).toBe("light");
+	});
+
+	test("updates forced theme and DOM configuration dynamically", () => {
+		const view = render(
+			<ClientThemeProvider forcedTheme="dark" attribute="class">
+				<ThemeConsumer />
+			</ClientThemeProvider>,
+		);
+		expect(document.documentElement.classList.contains("dark")).toBe(true);
+
+		view.rerender(
+			<ClientThemeProvider forcedTheme="light" attribute="data-theme">
+				<ThemeConsumer />
+			</ClientThemeProvider>,
+		);
+		expect(screen.getByTestId("forced").textContent).toBe("light");
+		expect(document.documentElement.getAttribute("data-theme")).toBe("light");
+	});
+
 	test("reports storage failures without breaking updates", () => {
 		const errors: unknown[] = [];
 		const originalDescriptor = Object.getOwnPropertyDescriptor(globalThis, "localStorage");

--- a/packages/themes/src/__tests__/client-provider.test.tsx
+++ b/packages/themes/src/__tests__/client-provider.test.tsx
@@ -261,6 +261,12 @@ describe("ClientThemeProvider - forcedTheme", () => {
 		expect(document.documentElement.classList.contains("dark")).toBe(true);
 		expect(document.documentElement.classList.contains("light")).toBe(false);
 	});
+
+	test("does not write storage when forcedTheme is set with initialTheme", () => {
+		wrap(<ThemeConsumer />, { forcedTheme: "dark", initialTheme: "light" });
+		expect(localStorage.getItem("theme")).toBeNull();
+		expect(screen.getByTestId("resolved").textContent).toBe("dark");
+	});
 });
 
 describe("ClientThemeProvider - initialTheme", () => {

--- a/packages/themes/src/__tests__/client-subpath-exports.test.ts
+++ b/packages/themes/src/__tests__/client-subpath-exports.test.ts
@@ -30,14 +30,6 @@ describe("client subpath exports", () => {
 		}
 	});
 
-	test("build config includes every client subpath entrypoint", () => {
-		const config = readFileSync(resolve(rootDir, "bunup.config.ts"), "utf-8");
-
-		for (const subpath of clientSubpaths) {
-			expect(config).toContain(`"src/client/${subpath}.ts`);
-		}
-	});
-
 	test("exposes the framework-neutral script entrypoint", () => {
 		const packageJson = JSON.parse(readFileSync(resolve(rootDir, "package.json"), "utf-8")) as {
 			exports: Record<string, { import?: { types?: string; default?: string } }>;

--- a/packages/themes/src/__tests__/theme-script.test.ts
+++ b/packages/themes/src/__tests__/theme-script.test.ts
@@ -1,6 +1,8 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import type { ReactElement } from "react";
 import { writeCookie } from "../core/cookie.js";
 import { getScript } from "../core/script.js";
+import { ThemeScript } from "../theme-script.js";
 import { clearCookies } from "./setup.js";
 
 beforeEach(() => {
@@ -24,6 +26,13 @@ afterEach(() => {
 function runScript(config: Parameters<typeof getScript>[0]): void {
 	// biome-ignore lint/security/noGlobalEval: intentional in test - runs inline theme script in happy-dom context
 	eval(getScript(config));
+}
+
+function getThemeScriptSource(props: Parameters<typeof ThemeScript>[0]): string | undefined {
+	const script = ThemeScript(props) as ReactElement<{
+		dangerouslySetInnerHTML?: { __html?: string };
+	}>;
+	return script.props.dangerouslySetInnerHTML?.__html;
 }
 
 const base = {
@@ -87,6 +96,35 @@ describe("themeScript - class attribute", () => {
 	test("uses defaultTheme when storage is empty", () => {
 		runScript({ ...base, enableSystem: false, defaultTheme: "dark" });
 		expect(document.documentElement.classList.contains("dark")).toBe(true);
+	});
+
+	test("does not query matchMedia when system resolution is unnecessary", () => {
+		let calls = 0;
+		window.matchMedia = () => {
+			calls += 1;
+			return { matches: true } as MediaQueryList;
+		};
+		runScript({ ...base, enableSystem: false, defaultTheme: "dark" });
+		expect(calls).toBe(0);
+		expect(document.documentElement.classList.contains("dark")).toBe(true);
+	});
+
+	test("falls back to the first custom theme for an invalid explicit default", () => {
+		const source = getThemeScriptSource({
+			themes: ["paper", "midnight"],
+			enableSystem: false,
+			defaultTheme: "invalid" as "paper",
+		});
+		expect(source).toContain('"paper",false');
+	});
+
+	test("falls back to light for an empty runtime theme array", () => {
+		const source = getThemeScriptSource({
+			themes: [],
+			enableSystem: false,
+			defaultTheme: "system",
+		});
+		expect(source).toContain('"light",false');
 	});
 });
 

--- a/packages/themes/src/core/theme-validation.ts
+++ b/packages/themes/src/core/theme-validation.ts
@@ -5,3 +5,19 @@ export function isThemeSelection(
 ): boolean {
 	return candidate === "system" ? enableSystem : !themes || themes.includes(candidate);
 }
+
+export function resolveDefaultTheme<Themes extends string>(
+	themes: readonly Themes[],
+	enableSystem: boolean,
+	defaultTheme: Themes | "system" | undefined,
+): Themes | "system" {
+	const fallback = (themes[0] ?? "light") as Themes;
+	if (defaultTheme !== undefined) {
+		if (defaultTheme === "system") {
+			return enableSystem ? "system" : fallback;
+		}
+		return themes.includes(defaultTheme) ? defaultTheme : fallback;
+	}
+
+	return enableSystem ? "system" : fallback;
+}

--- a/packages/themes/src/providers/client-next-provider.tsx
+++ b/packages/themes/src/providers/client-next-provider.tsx
@@ -1,7 +1,8 @@
 "use client";
 import { useServerInsertedHTML } from "next/navigation";
-import { type ReactElement, useRef } from "react";
+import { type ReactElement, useEffect, useRef } from "react";
 import { getScript } from "../core/script.js";
+import { resolveDefaultTheme } from "../core/theme-validation.js";
 import type { DefaultTheme, ThemeProviderProps } from "../core/types.js";
 import { ClientThemeProvider } from "./client-provider.js";
 
@@ -28,39 +29,68 @@ export function ClientNextThemeProvider<Themes extends string = DefaultTheme>(
 		initialTheme,
 		scriptProps,
 	} = props;
-	const resolvedDefault = (defaultTheme ?? (enableSystem ? "system" : "light")) as string;
+	const resolvedDefault = resolveDefaultTheme(themes, enableSystem, defaultTheme);
 	const inserted = useRef(false);
+	const scriptRef = useRef<HTMLScriptElement>(null);
+	const script = (
+		<script
+			{...scriptProps}
+			data-wrksz-theme-target={target}
+			ref={scriptRef}
+			suppressHydrationWarning
+			// biome-ignore lint/security/noDangerouslySetInnerHtml: inline script required to prevent flash of unstyled theme
+			dangerouslySetInnerHTML={{
+				__html: getScript({
+					storageKey,
+					attribute,
+					defaultTheme: resolvedDefault,
+					enableSystem,
+					enableColorScheme,
+					forcedTheme: forcedTheme as string | undefined,
+					themes,
+					value: valueMap,
+					target,
+					storage,
+					themeColors: themeColor,
+					initialTheme: initialTheme as string | undefined,
+					disableTransitionOnChange,
+					followSystem,
+				}),
+			}}
+			{...(nonce !== undefined ? { nonce } : null)}
+		/>
+	);
 
 	useServerInsertedHTML(() => {
+		if (target !== "html") return null;
 		if (inserted.current) return null;
 		inserted.current = true;
-		return (
-			<script
-				{...scriptProps}
-				suppressHydrationWarning
-				// biome-ignore lint/security/noDangerouslySetInnerHtml: inline script required to prevent flash of unstyled theme
-				dangerouslySetInnerHTML={{
-					__html: getScript({
-						storageKey,
-						attribute,
-						defaultTheme: resolvedDefault,
-						enableSystem,
-						enableColorScheme,
-						forcedTheme: forcedTheme as string | undefined,
-						themes,
-						value: valueMap,
-						target,
-						storage,
-						themeColors: themeColor,
-						initialTheme: initialTheme as string | undefined,
-						disableTransitionOnChange,
-						followSystem,
-					}),
-				}}
-				{...(nonce !== undefined ? { nonce } : null)}
-			/>
-		);
+		return script;
 	});
 
-	return <ClientThemeProvider {...props} />;
+	useEffect(() => {
+		if (target === "html") return;
+		const current = scriptRef.current;
+		if (!current) return;
+		const scripts = document.querySelectorAll<HTMLScriptElement>(
+			"script[data-wrksz-theme-target]",
+		);
+		for (const candidate of Array.from(scripts)) {
+			if (
+				candidate !== current &&
+				candidate.getAttribute("data-wrksz-theme-target") === target
+			) {
+				current.remove();
+				return;
+			}
+		}
+	}, [target]);
+
+	if (target === "html") return <ClientThemeProvider {...props} />;
+	return (
+		<>
+			<ClientThemeProvider {...props} />
+			{script}
+		</>
+	);
 }

--- a/packages/themes/src/providers/client-next-provider.tsx
+++ b/packages/themes/src/providers/client-next-provider.tsx
@@ -75,11 +75,9 @@ export function ClientNextThemeProvider<Themes extends string = DefaultTheme>(
 		const scripts = document.querySelectorAll<HTMLScriptElement>(
 			"script[data-wrksz-theme-target]",
 		);
-		for (const candidate of Array.from(scripts)) {
-			if (
-				candidate !== current &&
-				candidate.getAttribute("data-wrksz-theme-target") === target
-			) {
+		for (let i = 0; i < scripts.length; i++) {
+			const el = scripts[i];
+			if (el && el !== current && el.dataset.wrkszThemeTarget === target) {
 				current.remove();
 				return;
 			}

--- a/packages/themes/src/providers/client-provider.tsx
+++ b/packages/themes/src/providers/client-provider.tsx
@@ -117,7 +117,10 @@ export function ClientThemeProvider<Themes extends string = DefaultTheme>({
 		const system = mq ? (mq.matches ? "dark" : "light") : undefined;
 		let initial: Themes | "system";
 
-		if (initialTheme && isValidTheme(initialTheme)) {
+		// Forced theme short-circuits init and must not persist to storage.
+		if (validForcedTheme) {
+			initial = validForcedTheme;
+		} else if (initialTheme && isValidTheme(initialTheme)) {
 			initial = initialTheme;
 			writeStoredTheme(
 				storage,

--- a/packages/themes/src/providers/client-provider.tsx
+++ b/packages/themes/src/providers/client-provider.tsx
@@ -9,7 +9,7 @@ import {
 } from "../core/client-dom.js";
 import { ThemeContext, type ThemeContextInstance } from "../core/context.js";
 import { createThemeStore } from "../core/store.js";
-import { isThemeSelection } from "../core/theme-validation.js";
+import { isThemeSelection, resolveDefaultTheme } from "../core/theme-validation.js";
 import type {
 	DefaultTheme,
 	ResolvedTheme,
@@ -46,15 +46,12 @@ export function ClientThemeProvider<Themes extends string = DefaultTheme>({
 	onStorageError,
 	themeContext = ThemeContext as ThemeContextInstance<Themes>,
 }: ClientThemeProviderProps<Themes>): ReactElement {
-	const requestedDefault = defaultTheme ?? (enableSystem ? "system" : themes[0]);
-	const resolvedDefault = (
-		themes.includes(requestedDefault as Themes) ||
-		(enableSystem && requestedDefault === "system")
-			? requestedDefault
-			: themes[0]
-	) as Themes | "system";
+	const resolvedDefault = resolveDefaultTheme(themes, enableSystem, defaultTheme);
 
-	const storeRef = useRef(createThemeStore());
+	const storeRef = useRef<ReturnType<typeof createThemeStore> | null>(null);
+	if (storeRef.current === null) {
+		storeRef.current = createThemeStore();
+	}
 	const store = storeRef.current;
 	const {
 		getSnapshot,
@@ -110,26 +107,18 @@ export function ClientThemeProvider<Themes extends string = DefaultTheme>({
 		],
 	);
 	const applyToDomEvent = useEffectEvent(applyToDom);
-
-	// biome-ignore lint/correctness/useExhaustiveDependencies: effect events are intentionally non-reactive.
-	useEffect(() => {
+	const initializeEvent = useEffectEvent(() => {
 		const domWindow = getDomWindow();
 		if (!domWindow) return;
 		const mq =
 			enableSystem && typeof domWindow.matchMedia === "function"
 				? domWindow.matchMedia("(prefers-color-scheme: dark)")
 				: null;
-		const sys: "light" | "dark" | undefined = mq ? (mq.matches ? "dark" : "light") : undefined;
-		if (sys) {
-			setStoreSystemTheme(sys);
-		}
+		const system = mq ? (mq.matches ? "dark" : "light") : undefined;
+		let initial: Themes | "system";
 
-		if (validForcedTheme) {
-			setStoreTheme(validForcedTheme);
-			applyToDom(validForcedTheme);
-		} else if (initialTheme && isValidTheme(initialTheme)) {
-			setStoreTheme(initialTheme);
-			applyToDom(initialTheme === "system" ? (sys ?? "light") : initialTheme);
+		if (initialTheme && isValidTheme(initialTheme)) {
+			initial = initialTheme;
 			writeStoredTheme(
 				storage,
 				storageKey,
@@ -139,48 +128,47 @@ export function ClientThemeProvider<Themes extends string = DefaultTheme>({
 			);
 		} else {
 			const stored = readStoredTheme(storage, storageKey, onStorageError);
-
-			const initial =
+			initial =
 				!followSystem && stored && isValidTheme(stored)
 					? (stored as Themes | "system")
 					: resolvedDefault;
-
-			setStoreState({ theme: initial, systemTheme: sys });
-			applyToDom(initial === "system" ? (sys ?? "light") : initial);
 		}
 
-		if (!mq) return;
-		const handler = (e: MediaQueryListEvent) => {
-			const next = e.matches ? "dark" : "light";
-			setStoreSystemTheme(next);
-			const current = getSnapshot().theme;
-			if (current === "system" || current === undefined || followSystem) {
-				if (followSystem) {
-					setStoreTheme("system");
-				}
-				applyToDomEvent(next);
-				onThemeChangeEvent(next as Themes);
+		setStoreState({ theme: initial, systemTheme: system });
+	});
+	const handleSystemChangeEvent = useEffectEvent((next: "light" | "dark") => {
+		setStoreSystemTheme(next);
+		const current = getSnapshot().theme;
+		if (current === "system" || current === undefined || followSystem) {
+			if (followSystem) {
+				setStoreTheme("system");
 			}
+			applyToDomEvent(next);
+			onThemeChangeEvent(next as Themes);
+		}
+	});
+
+	// biome-ignore lint/correctness/useExhaustiveDependencies: effect events are intentionally non-reactive.
+	useEffect(() => {
+		initializeEvent();
+	}, []);
+
+	useEffect(() => {
+		if (resolvedTheme) applyToDom(resolvedTheme);
+	}, [resolvedTheme, applyToDom]);
+
+	// biome-ignore lint/correctness/useExhaustiveDependencies: effect events are intentionally non-reactive.
+	useEffect(() => {
+		const domWindow = getDomWindow();
+		if (!enableSystem || !domWindow || typeof domWindow.matchMedia !== "function") return;
+		const mq = domWindow.matchMedia("(prefers-color-scheme: dark)");
+		setStoreSystemTheme(mq.matches ? "dark" : "light");
+		const handler = (event: MediaQueryListEvent) => {
+			handleSystemChangeEvent(event.matches ? "dark" : "light");
 		};
 		mq.addEventListener?.("change", handler);
 		return () => mq.removeEventListener?.("change", handler);
-	}, [
-		cookieOptions,
-		validForcedTheme,
-		initialTheme,
-		resolvedDefault,
-		storage,
-		storageKey,
-		enableSystem,
-		followSystem,
-		isValidTheme,
-		onStorageError,
-		applyToDom,
-		getSnapshot,
-		setStoreState,
-		setStoreTheme,
-		setStoreSystemTheme,
-	]);
+	}, [enableSystem, setStoreSystemTheme]);
 
 	// Re-apply theme on bfcache restore (pageshow) and history navigation (popstate)
 	// biome-ignore lint/correctness/useExhaustiveDependencies: effect events are intentionally non-reactive.

--- a/packages/themes/src/theme-script.tsx
+++ b/packages/themes/src/theme-script.tsx
@@ -1,5 +1,6 @@
 import type { ReactElement } from "react";
 import { getScript } from "./core/script.js";
+import { resolveDefaultTheme } from "./core/theme-validation.js";
 import type { DefaultTheme, ThemeProviderProps } from "./core/types.js";
 
 const DEFAULT_THEMES: string[] = ["light", "dark"];
@@ -27,7 +28,7 @@ export function ThemeScript<Themes extends string = DefaultTheme>({
 	followSystem = false,
 	initialTheme,
 }: ThemeScriptProps<Themes>): ReactElement {
-	const resolvedDefault = defaultTheme ?? (enableSystem ? "system" : (themes[0] ?? "light"));
+	const resolvedDefault = resolveDefaultTheme(themes, enableSystem, defaultTheme);
 
 	return (
 		<script


### PR DESCRIPTION
## Stack

PR 7 of 9. Depends on `split/06-next-16-3`. This cumulative upstream PR targets `main`; review the commits after `split/06-next-16-3` for this PRs isolated scope.

## Summary

- Stabilize provider initialization so configuration-object rerenders do not reset user state.
- Keep bootstrap, client DOM application, and provider default resolution behavior aligned.
- Add parity tests for mapped classes, custom system themes, invalid defaults, forced themes, and disabled system mode.
- Define build entries once and consume them from Bunup, bundle measurement, and export lockstep tests.
- Add dedicated bootstrap, generated-script, client-provider, and Next-provider bundle surfaces and budgets.

## Breaking changes

None intended. Initialization now avoids repeated storage writes and state resets that were previously observable bugs.

## Verification

- Bootstrap/runtime parity tests passed.
- Package test suite and type-check passed.
- Build/export lockstep and bundle budgets passed.