### PR TITLE
ci(types)!: require TypeScript 5.9 and add compatibility matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,6 +95,33 @@ jobs:
       - name: Build
         run: bun run --cwd packages/themes build
 
+  typescript-compatibility:
+    name: TypeScript ${{ matrix.version }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - version: "5.9.3"
+            script: "type-check:compat:5.9"
+          - version: "6.0.2"
+            script: "type-check:compat:6"
+          - version: "7.0.2"
+            script: "type-check:compat:7"
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.9
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Check source and published package
+        run: bun run --cwd packages/themes ${{ matrix.script }}
+
   next-16-3:
     name: Next.js 16.3 Instant Navigations
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -6,9 +6,11 @@
 [![docs](https://shieldcn.dev/badge/docs-themes.wrksz.dev-7C3AED.png?logo=readthedocs&variant=secondary&size=sm)](https://themes.wrksz.dev)
 ![Next.js](https://shieldcn.dev/badge/Next.js-16-000000.png?logo=nextdotjs&variant=secondary&size=sm)
 ![React](https://shieldcn.dev/badge/React-19-087EA4.png?logo=react&variant=secondary&size=sm)
-![TypeScript](https://shieldcn.dev/badge/TypeScript-5.9-3178C6.png?logo=typescript&variant=secondary&size=sm)
+![TypeScript](https://shieldcn.dev/badge/TypeScript-5.9%E2%80%937-3178C6.png?logo=typescript&variant=secondary&size=sm)
 
 Modern theme management for Next.js 16+ and React 19+. Near drop-in replacement for `next-themes` - fixes every known bug and adds missing features. Migrating requires changing one import line.
+
+TypeScript 5.9, 6, and 7 are supported and checked against the published package declarations in CI.
 
 ```bash
 bun add @wrksz/themes

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 Modern theme management for Next.js 16+ and React 19+. Near drop-in replacement for `next-themes` - fixes every known bug and adds missing features. Migrating requires changing one import line.
 
-TypeScript 5.9, 6, and 7 are supported and checked against the published package declarations in CI.
+TypeScript 5.9 or newer is required. TypeScript 5.9, 6, and 7 are supported and checked against the published package declarations in CI.
 
 ```bash
 bun add @wrksz/themes

--- a/apps/docs/content/docs/migration.mdx
+++ b/apps/docs/content/docs/migration.mdx
@@ -43,6 +43,7 @@ That's it for most apps.
 
 `ThemeProvider` from `@wrksz/themes/next` no longer reads the request cookie implicitly and no longer sets `initialTheme` for you.
 
+- TypeScript 5.9 or newer is required (`typescript` peer dependency is now `>=5.9`; 4.x and 5.0–5.8 are no longer supported).
 - For zero-flash theme application, keep using cookie or hybrid storage. The pre-hydration bootstrap still reads the stored theme before paint.
 - If server-rendered markup must depend on the cookie (for example setting `<html className={theme}>`), call [`getTheme`](/docs/api/get-theme) explicitly and pass `initialTheme`, and opt the layout out of Instant Navigations with `export const instant = false` when that request-time read would block the static App Shell.
 

--- a/bun.lock
+++ b/bun.lock
@@ -71,7 +71,7 @@
         "next": ">=16.0.0",
         "react": "^18.0.0 || ^19.0.0",
         "react-dom": "^18.0.0 || ^19.0.0",
-        "typescript": ">=4.5.0",
+        "typescript": ">=5.9",
       },
       "optionalPeers": [
         "next",

--- a/packages/themes/README.md
+++ b/packages/themes/README.md
@@ -2,6 +2,8 @@
 
 Modern theme management for Next.js and React. It keeps the `next-themes` style API, adds typed helpers, and fixes React 19 / Next.js App Router edge cases around inline scripts, server themes, cookies, and hydration.
 
+Supports TypeScript 5.9, 6, and 7.
+
 [Docs](https://themes.wrksz.dev) · [GitHub](https://github.com/jakubwarkusz/themes)
 
 ```bash

--- a/packages/themes/README.md
+++ b/packages/themes/README.md
@@ -2,7 +2,7 @@
 
 Modern theme management for Next.js and React. It keeps the `next-themes` style API, adds typed helpers, and fixes React 19 / Next.js App Router edge cases around inline scripts, server themes, cookies, and hydration.
 
-Supports TypeScript 5.9, 6, and 7.
+Requires TypeScript 5.9 or newer. TypeScript 5.9, 6, and 7 are supported.
 
 [Docs](https://themes.wrksz.dev) · [GitHub](https://github.com/jakubwarkusz/themes)
 

--- a/packages/themes/package.json
+++ b/packages/themes/package.json
@@ -17,6 +17,10 @@
     "build": "bun run generate:script-source && bunup",
     "dev": "bunup --watch",
     "type-check": "tsc --noEmit",
+    "type-check:compat:5.9": "bun run build && bunx --package typescript@5.9.3 tsc --noEmit && bunx --package typescript@5.9.3 tsc -p tsconfig.compat.json && bun scripts/smoke-exports.ts",
+    "type-check:compat:6": "bun run build && bunx --package typescript@6.0.2 tsc --noEmit --stableTypeOrdering && bunx --package typescript@6.0.2 tsc -p tsconfig.compat.json --stableTypeOrdering && bun scripts/smoke-exports.ts",
+    "type-check:compat:7": "bun run build && bunx --package typescript@7.0.2 tsc --noEmit && bunx --package typescript@7.0.2 tsc -p tsconfig.compat.json && bun scripts/smoke-exports.ts",
+    "type-check:compat": "bun run type-check:compat:5.9 && bun run type-check:compat:6 && bun run type-check:compat:7",
     "lint": "biome check src",
     "lint:fix": "biome check --write src",
     "format": "biome format --write src",
@@ -31,7 +35,7 @@
     "next": ">=16.0.0",
     "react": "^18.0.0 || ^19.0.0",
     "react-dom": "^18.0.0 || ^19.0.0",
-    "typescript": ">=4.5.0"
+    "typescript": ">=5.9"
   },
   "peerDependenciesMeta": {
     "next": {

--- a/packages/themes/scripts/smoke-exports.ts
+++ b/packages/themes/scripts/smoke-exports.ts
@@ -1,0 +1,35 @@
+import * as root from "@wrksz/themes";
+import * as client from "@wrksz/themes/client";
+import * as createThemes from "@wrksz/themes/client/create-themes";
+import * as provider from "@wrksz/themes/client/provider";
+import * as themedImage from "@wrksz/themes/client/themed-image";
+import * as useHydrated from "@wrksz/themes/client/use-hydrated";
+import * as useTheme from "@wrksz/themes/client/use-theme";
+import * as useThemeEffect from "@wrksz/themes/client/use-theme-effect";
+import * as useThemeValue from "@wrksz/themes/client/use-theme-value";
+import * as next from "@wrksz/themes/next";
+import * as script from "@wrksz/themes/script";
+
+const entrypoints = [
+	[".", root, ["ThemeProvider", "createThemes"]],
+	["./client", client, ["ClientThemeProvider", "useTheme"]],
+	["./client/create-themes", createThemes, ["createThemes"]],
+	["./client/provider", provider, ["ClientThemeProvider"]],
+	["./client/themed-image", themedImage, ["ThemedImage"]],
+	["./client/use-hydrated", useHydrated, ["useHydrated"]],
+	["./client/use-theme", useTheme, ["ThemeContext", "useTheme"]],
+	["./client/use-theme-effect", useThemeEffect, ["useThemeEffect"]],
+	["./client/use-theme-value", useThemeValue, ["useThemeValue"]],
+	["./next", next, ["ThemeProvider", "getTheme"]],
+	["./script", script, ["ThemeScript"]],
+] as const;
+
+for (const [subpath, module, expectedExports] of entrypoints) {
+	for (const exportName of expectedExports) {
+		if (!(exportName in module)) {
+			throw new Error(
+				`Missing ${exportName} export from @wrksz/themes${subpath === "." ? "" : subpath}`,
+			);
+		}
+	}
+}

--- a/packages/themes/src/__tests__/client-subpath-exports.test.ts
+++ b/packages/themes/src/__tests__/client-subpath-exports.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
+import {
+	DECLARATION_BUILD_ENTRIES,
+	INTERNAL_RUNTIME_BUILD_ENTRIES,
+	PUBLIC_BUILD_ENTRIES,
+	RUNTIME_BUILD_ENTRIES,
+} from "../../build-entries.js";
 
 const rootDir = resolve(import.meta.dir, "../..");
 
@@ -40,5 +46,39 @@ describe("client subpath exports", () => {
 				default: "./dist/script.js",
 			},
 		});
+	});
+
+	test("keeps every public export in build, declaration, and smoke coverage", () => {
+		const packageJson = JSON.parse(readFileSync(resolve(rootDir, "package.json"), "utf-8")) as {
+			exports: Record<string, { import?: { types?: string; default?: string } } | string>;
+		};
+		const smoke = readFileSync(resolve(rootDir, "scripts/smoke-exports.ts"), "utf-8");
+		const publicSourceEntries: string[] = [];
+
+		for (const [subpath, exported] of Object.entries(packageJson.exports)) {
+			if (subpath === "./package.json" || typeof exported === "string") continue;
+			const runtimePath = exported.import?.default;
+			const declarationPath = exported.import?.types;
+			expect(runtimePath).toBeDefined();
+			expect(declarationPath).toBeDefined();
+
+			const sourceEntry = subpath === "." ? "src/index.ts" : `src/${subpath.slice(2)}.ts`;
+			publicSourceEntries.push(sourceEntry);
+			const importSpecifier =
+				subpath === "." ? '"@wrksz/themes"' : `"@wrksz/themes/${subpath.slice(2)}"`;
+			expect(smoke).toContain(importSpecifier);
+		}
+
+		const publicEntries: string[] = [...PUBLIC_BUILD_ENTRIES];
+		const declarationEntries: string[] = [...DECLARATION_BUILD_ENTRIES];
+		const runtimeEntries: string[] = [...RUNTIME_BUILD_ENTRIES];
+		expect(publicEntries.sort()).toEqual(publicSourceEntries.sort());
+		expect(declarationEntries.sort()).toEqual(publicSourceEntries.sort());
+		expect([...INTERNAL_RUNTIME_BUILD_ENTRIES]).toEqual([
+			"src/providers/client-next-provider.tsx",
+		]);
+		expect(runtimeEntries.sort()).toEqual(
+			[...publicSourceEntries, ...INTERNAL_RUNTIME_BUILD_ENTRIES].sort(),
+		);
 	});
 });

--- a/packages/themes/test-d/public-api.tsx
+++ b/packages/themes/test-d/public-api.tsx
@@ -1,0 +1,116 @@
+import {
+	ClientThemeProvider,
+	createThemes,
+	ThemedImage,
+	ThemeContext,
+	useHydrated,
+	useTheme,
+	useThemeEffect,
+	useThemeValue,
+} from "@wrksz/themes/client";
+import { createThemes as createThemesSubpath } from "@wrksz/themes/client/create-themes";
+import { useHydrated as useHydratedSubpath } from "@wrksz/themes/client/use-hydrated";
+import { ClientThemeProvider as ClientThemeProviderSubpath } from "@wrksz/themes/client/provider";
+import { ThemedImage as ThemedImageSubpath } from "@wrksz/themes/client/themed-image";
+import {
+	ThemeContext as ThemeContextSubpath,
+	useTheme as useThemeSubpath,
+} from "@wrksz/themes/client/use-theme";
+import { useThemeEffect as useThemeEffectSubpath } from "@wrksz/themes/client/use-theme-effect";
+import { useThemeValue as useThemeValueSubpath } from "@wrksz/themes/client/use-theme-value";
+import {
+	createThemes as createRootThemes,
+	ThemeProvider as RootThemeProvider,
+} from "@wrksz/themes";
+import type { ReactNode } from "react";
+import type {
+	CookieOptions,
+	ThemeColor,
+	ThemeContextValue,
+	ThemeProviderProps,
+} from "@wrksz/themes";
+import { getTheme, ThemeProvider as NextThemeProvider } from "@wrksz/themes/next";
+import { ThemeScript } from "@wrksz/themes/script";
+
+const themes = ["light", "dark", "high-contrast"] as const;
+type AppTheme = (typeof themes)[number];
+
+const configured = createThemes({
+	themes,
+	defaultTheme: "system",
+	themeColor: {
+		light: "#fff",
+		dark: "#000",
+		"high-contrast": "#ff0",
+	},
+});
+
+const providerProps = {
+	children: null,
+	themes,
+	defaultTheme: "light",
+	cookieOptions: {
+		sameSite: "Lax",
+		secure: true,
+	} satisfies CookieOptions,
+	themeColor: {
+		light: "#fff",
+		dark: "#000",
+	} satisfies ThemeColor<AppTheme>,
+} satisfies ThemeProviderProps<AppTheme>;
+
+function TypeConsumer(): ReactNode {
+	const context = configured.useTheme();
+	const standaloneContext = useTheme<AppTheme>();
+	const image = (
+		<configured.ThemedImage
+			alt="Theme preview"
+			src={{
+				light: "/light.png",
+				dark: "/dark.png",
+				"high-contrast": "/contrast.png",
+			}}
+		/>
+	);
+
+	const typedContext: ThemeContextValue<AppTheme> = context;
+	const typedStandaloneContext: ThemeContextValue<AppTheme> = standaloneContext;
+	return (
+		<>
+			{image}
+			{typedContext.theme}
+			{typedStandaloneContext.resolvedTheme}
+		</>
+	);
+}
+
+const syncTheme = getTheme(new Request("https://example.com"), {
+	themes,
+	defaultTheme: "light",
+});
+const checkedTheme: AppTheme = syncTheme;
+
+export {
+	checkedTheme,
+	ClientThemeProvider,
+	ClientThemeProviderSubpath,
+	configured,
+	createRootThemes,
+	createThemesSubpath,
+	NextThemeProvider,
+	providerProps,
+	RootThemeProvider,
+	ThemedImage,
+	ThemedImageSubpath,
+	ThemeContext,
+	ThemeContextSubpath,
+	ThemeScript,
+	TypeConsumer,
+	useHydrated,
+	useHydratedSubpath,
+	useThemeEffect,
+	useThemeEffectSubpath,
+	useThemeSubpath,
+	useThemeValue,
+	useThemeValueSubpath,
+};

--- a/packages/themes/tsconfig.compat.json
+++ b/packages/themes/tsconfig.compat.json
@@ -1,0 +1,19 @@
+{
+	"compilerOptions": {
+		"lib": ["ES2023", "DOM"],
+		"target": "ES2023",
+		"module": "Preserve",
+		"moduleResolution": "bundler",
+		"moduleDetection": "force",
+		"jsx": "react-jsx",
+		"strict": true,
+		"exactOptionalPropertyTypes": true,
+		"noEmit": true,
+		"noUncheckedIndexedAccess": true,
+		"noUncheckedSideEffectImports": true,
+		"skipLibCheck": false,
+		"types": ["react", "react-dom"],
+		"verbatimModuleSyntax": true
+	},
+	"include": ["test-d/**/*.ts", "test-d/**/*.tsx"]
+}


### PR DESCRIPTION
## Stack

PR 8 of 9. Depends on `split/07-bootstrap-parity`. This cumulative upstream PR targets `main`; review the commits after `split/07-bootstrap-parity` for this PRs isolated scope.

## Summary

- Raise the published TypeScript peer minimum from 4.5 to 5.9.
- Add source and published-declaration checks for TypeScript 5.9, 6, and 7.
- Add `tsconfig.compat.json` and public-package type fixtures.
- Smoke-import every public runtime entry after building.
- Lock public exports, runtime entries, declaration entries, and smoke coverage together.

## Breaking changes

Consumers must use TypeScript 5.9 or newer. Projects pinned to TypeScript 4.x or TypeScript 5.0-5.8 must upgrade before adopting the release containing this PR.

## Verification

- TypeScript 5.9 compatibility check passed.
- TypeScript 6 compatibility check passed.
- TypeScript 7 compatibility check passed.
- Published export smoke test passed.