### PR TITLE
ci: align docs, release, and support tooling

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -74,7 +74,7 @@ body:
     id: framework_version
     attributes:
       label: Framework version
-      placeholder: "e.g. Next.js 15.1.0, React 19.0.0"
+      placeholder: "e.g. Next.js 16.2.11, React 19.2.4"
     validations:
       required: false
 

--- a/.github/ISSUE_TEMPLATE/framework_support.yml
+++ b/.github/ISSUE_TEMPLATE/framework_support.yml
@@ -7,7 +7,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        @wrksz/themes currently targets **Next.js 16+ (App Router) and React 19.2+**.
+        @wrksz/themes currently targets **Next.js 16+ (App Router) and React 18+**.
         Use this template to request support for other frameworks.
 
   - type: input

--- a/.github/ISSUE_TEMPLATE/framework_support.yml
+++ b/.github/ISSUE_TEMPLATE/framework_support.yml
@@ -7,7 +7,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        @wrksz/themes currently targets **Next.js 16+ (App Router) and React 19+**.
+        @wrksz/themes currently targets **Next.js 16+ (App Router) and React 19.2+**.
         Use this template to request support for other frameworks.
 
   - type: input

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,35 +1,45 @@
----
 version: 2
 updates:
     - package-ecosystem: "bun"
       directory: "/"
-      target-branch: "development"
+      target-branch: "main"
       open-pull-requests-limit: 10
       schedule:
           timezone: "Europe/Warsaw"
-          interval: "semiannually"
+          interval: "weekly"
       commit-message:
           prefix: "chore(deps->root):"
       labels: ["🔄 dependencies"]
-    
+
     - package-ecosystem: "bun"
       directory: "/packages/themes"
-      target-branch: "development"
+      target-branch: "main"
       open-pull-requests-limit: 10
       schedule:
           timezone: "Europe/Warsaw"
-          interval: "semiannually"
+          interval: "weekly"
       commit-message:
           prefix: "chore(deps->themes):"
       labels: ["🔄 dependencies"]
 
     - package-ecosystem: "bun"
       directory: "/apps/docs"
-      target-branch: "development"
+      target-branch: "main"
       open-pull-requests-limit: 10
       schedule:
           timezone: "Europe/Warsaw"
-          interval: "semiannually"
+          interval: "weekly"
       commit-message:
           prefix: "chore(deps->docs):"
+      labels: ["🔄 dependencies"]
+
+    - package-ecosystem: "github-actions"
+      directory: "/"
+      target-branch: "main"
+      open-pull-requests-limit: 10
+      schedule:
+          timezone: "Europe/Warsaw"
+          interval: "weekly"
+      commit-message:
+          prefix: "chore(deps->actions):"
       labels: ["🔄 dependencies"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,13 +22,15 @@ on:
       - "biome.json"
       - ".github/workflows/ci.yml"
 
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
-  check:
-    name: Lint, type-check & build
+  quality:
+    name: Repository quality
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: packages/themes
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
 
@@ -38,25 +40,41 @@ jobs:
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
-        working-directory: .
 
       - name: Lint
-        run: bunx biome check src
+        run: bun run lint
+
+      - name: Audit high severity dependencies
+        run: bun audit --audit-level=high
+
+  library:
+    name: Library
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.9
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
 
       - name: Type check
-        run: bun type-check
+        run: bun run --cwd packages/themes type-check
 
       - name: Test
-        run: bun test
+        run: bun run --cwd packages/themes test
 
       - name: Build
-        run: bun run build
+        run: bun run --cwd packages/themes build
 
       - name: Bundle size
-        run: bun run size
+        run: bun run --cwd packages/themes size
 
       - name: Bundle size baseline
-        run: bun run size:compare benchmarks/baseline.json
+        run: bun run --cwd packages/themes size:compare
 
   react-compatibility:
     name: React ${{ matrix.react }}
@@ -121,6 +139,29 @@ jobs:
 
       - name: Check source and published package
         run: bun run --cwd packages/themes ${{ matrix.script }}
+
+  docs:
+    name: Documentation
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.9
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Test
+        run: bun run --cwd apps/docs test
+
+      - name: Type check
+        run: bun run --cwd apps/docs types:check
+
+      - name: Build
+        run: bun run build:docs
 
   next-16-3:
     name: Next.js 16.3 Instant Navigations

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,6 +154,9 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
+      - name: Build library
+        run: bun run --cwd packages/themes build
+
       - name: Test
         run: bun run --cwd apps/docs test
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
-          node-version: latest
+          node-version: 24
           registry-url: https://registry.npmjs.org
 
       - name: Setup Bun
@@ -47,6 +47,12 @@ jobs:
 
       - name: Build
         run: bun run build
+
+      - name: Declaration compatibility
+        run: bun run type-check:compat
+
+      - name: Bundle size baseline
+        run: bun run size:compare
 
       - name: Publish to NPM registry
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,24 @@
+# Agent guidance
+
+## Repository map
+
+- `packages/themes`: publishable library, tests, build configuration, and bundle budgets.
+- `apps/docs`: canonical API documentation and examples.
+- `apps/next-16-3`: preview fixture for Next.js Instant Navigation, hydration, and bootstrap behavior.
+
+## Working rules
+
+- Use Bun 1.3.x and run `CI=true bun install --frozen-lockfile`.
+- Keep runtime dependencies at zero and imports at module scope.
+- Preserve bootstrap/runtime parity: changes to the inline script, DOM applier, or providers need equivalent tests.
+- Keep package exports, Bunup runtime/declaration entries, and smoke imports in lockstep.
+- Do not increase bundle budgets merely to make CI pass.
+- Public support starts at React/React DOM 19.2, Next.js 16, and TypeScript 5.9.
+
+## Verification
+
+- Fast: `bun run verify`
+- Full release/CI parity: `bun run verify:full`
+- Library only: `bun run --cwd packages/themes test`
+
+The docs site is the canonical API reference. Link to it instead of duplicating prop tables.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,8 @@
 - Preserve bootstrap/runtime parity: changes to the inline script, DOM applier, or providers need equivalent tests.
 - Keep package exports, Bunup runtime/declaration entries, and smoke imports in lockstep.
 - Do not increase bundle budgets merely to make CI pass.
-- Public support starts at React/React DOM 19.2, Next.js 16, and TypeScript 5.9.
+- Public support starts at React/React DOM 18, Next.js 16, and TypeScript 5.9.
+- React 19.2+ uses the native `useEffectEvent`; React 18 and earlier React 19 releases use the compatibility fallback.
 
 ## Verification
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,25 @@
+# Contributing
+
+## Setup
+
+Install Bun 1.3.x, then run:
+
+```sh
+CI=true bun install --frozen-lockfile
+bun run verify
+```
+
+Use `bun run verify:full` before requesting release review. It adds TypeScript 5.9/6/7 declaration checks, bundle comparison, production builds, dependency audit, and the Next.js Playwright fixture.
+
+## Change expectations
+
+- Add characterization tests before changing bootstrap or provider behavior.
+- Exercise equivalent configurations through `getScript`, direct DOM application, and provider wiring.
+- Keep the package free of runtime dependencies.
+- Update package exports, Bunup JavaScript/declaration entries, and `scripts/smoke-exports.ts` together.
+- Review bundle baselines after correctness work; never raise a threshold solely to pass CI.
+- Use conventional commit messages.
+
+The supported minimums are React and React DOM 19.2, Next.js 16, and TypeScript 5.9. The `apps/next-16-3` preview fixture protects behavior against upcoming Next.js routing changes.
+
+API documentation belongs in `apps/docs/content/docs`; avoid parallel prop tables in README files. Releases are tag-driven from `vMAJOR.MINOR.PATCH` tags, optionally with dot-separated prerelease identifiers, and are published only by the provenance-enabled workflow.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 
-
 # @wrksz/themes
 
 [![npm](https://shieldcn.dev/badge/npm-%40wrksz%2Fthemes-CB3837.png?logo=npm&variant=secondary&size=sm)](https://www.npmjs.com/package/@wrksz/themes)
@@ -20,7 +19,6 @@ npm install @wrksz/themes
 
 ## Why not `next-themes`?
 
-
 |                                                 | next-themes | @wrksz/themes             |
 | ----------------------------------------------- | ----------- | ------------------------- |
 | React 19 script warning                         | ❌           | ✅ `useServerInsertedHTML` |
@@ -39,8 +37,9 @@ npm install @wrksz/themes
 | Generic types                                   | ❌           | ✅ `useTheme<AppTheme>()`  |
 | Typed factory                                   | ❌           | ✅ `createThemes(...)`     |
 | Theme-change effect hook                        | ❌           | ✅ `useThemeEffect(...)`   |
+| Hydration state without mount effects           | ❌           | ✅ `useHydrated()`         |
+| Framework-neutral SSR bootstrap                 | ❌           | ✅ `@wrksz/themes/script`  |
 | Zero runtime dependencies                       | ✅           | ✅                         |
-
 
 ## Table of Contents
 
@@ -157,7 +156,6 @@ with npm provenance from GitHub Actions.
 
 ### `ThemeProvider`
 
-
 | Prop                        | Type                                                               | Default             | Description                                                                                                                                                                                                                        |
 | --------------------------- | ------------------------------------------------------------------ | ------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `themes`                    | `string[]`                                                         | `["light", "dark"]` | Available themes                                                                                                                                                                                                                   |
@@ -176,7 +174,9 @@ with npm provenance from GitHub Actions.
 | `themeColor`                | `string \| Record<string, string>`                                  | -                   | Update `<meta name="theme-color">` on theme change                                                                                                                                                                                 |
 | `nonce`                     | `string`                                                           | -                   | CSP nonce for the inline script                                                                                                                                                                                                    |
 | `onThemeChange`             | `(theme: string) => void`                                          | -                   | Called when theme changes. Receives the selected value (may be `"system"`). When system preference changes while theme is `"system"`, fires with the resolved value                                                                |
-
+| `onStorageError`            | `(error: unknown) => void`                                         | -                   | Reports storage failures without interrupting in-memory theme updates |
+| `systemThemeMap`            | serializable light/dark mapping                                    | -                   | Resolve system preferences to custom theme variants in both bootstrap and client runtime |
+| `scriptProps`               | `ScriptHTMLAttributes<HTMLScriptElement>`                           | -                   | Extra bootstrap script attributes |
 
 ### `useTheme`
 
@@ -228,13 +228,11 @@ const theme = getTheme(request, {
 // theme: "light" | "dark" | "high-contrast"
 ```
 
-
 | Option         | Type       | Default    | Description                                                              |
 | -------------- | ---------- | ---------- | ------------------------------------------------------------------------ |
 | `storageKey`   | `string`   | `"theme"`  | Cookie name to read from                                                 |
 | `defaultTheme` | `string`   | `"system"` | Returned when no valid theme is found                                    |
 | `themes`       | `readonly string[]` | -          | When provided, stored values not in the list fall back to `defaultTheme`. Use `as const` for return type inference |
-
 
 ### `useThemeValue`
 
@@ -415,6 +413,7 @@ Fine-grained client subpaths are also available for consumers who prefer direct 
 import { useTheme } from "@wrksz/themes/client/use-theme";
 import { useThemeValue } from "@wrksz/themes/client/use-theme-value";
 import { useThemeEffect } from "@wrksz/themes/client/use-theme-effect";
+import { useHydrated } from "@wrksz/themes/client/use-hydrated";
 import { ThemedImage } from "@wrksz/themes/client/themed-image";
 import { ClientThemeProvider } from "@wrksz/themes/client/provider";
 import { createThemes } from "@wrksz/themes/client/create-themes";
@@ -427,11 +426,12 @@ import { createThemes } from "@wrksz/themes/client/create-themes";
 | `@wrksz/themes/client/use-theme` | Direct `useTheme` import |
 | `@wrksz/themes/client/use-theme-value` | Direct `useThemeValue` import |
 | `@wrksz/themes/client/use-theme-effect` | Direct `useThemeEffect` import |
+| `@wrksz/themes/client/use-hydrated` | Direct `useHydrated` import |
 | `@wrksz/themes/client/themed-image` | Direct `ThemedImage` import |
 | `@wrksz/themes/client/provider` | Direct `ClientThemeProvider` import |
 | `@wrksz/themes/client/create-themes` | Direct `createThemes` import |
 | `@wrksz/themes`        | Client-safe `ThemeProvider` alias and `createThemes` for framework-neutral React usage              |
-
+| `@wrksz/themes/script` | Server-safe `ThemeScript` for non-Next SSR frameworks |
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 ![React](https://shieldcn.dev/badge/React-19-087EA4.png?logo=react&variant=secondary&size=sm)
 ![TypeScript](https://shieldcn.dev/badge/TypeScript-5.9%E2%80%937-3178C6.png?logo=typescript&variant=secondary&size=sm)
 
-Modern theme management for Next.js 16+ and React 19+. Near drop-in replacement for `next-themes` - fixes every known bug and adds missing features. Migrating requires changing one import line.
+Modern theme management for Next.js 16+ and React 19.2+. Near drop-in replacement for `next-themes` - fixes every known bug and adds missing features. Migrating requires changing one import line.
 
 TypeScript 5.9 or newer is required. TypeScript 5.9, 6, and 7 are supported and checked against the published package declarations in CI.
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 ![React](https://shieldcn.dev/badge/React-19-087EA4.png?logo=react&variant=secondary&size=sm)
 ![TypeScript](https://shieldcn.dev/badge/TypeScript-5.9%E2%80%937-3178C6.png?logo=typescript&variant=secondary&size=sm)
 
-Modern theme management for Next.js 16+ and React 19.2+. Near drop-in replacement for `next-themes` - fixes every known bug and adds missing features. Migrating requires changing one import line.
+Modern theme management for Next.js 16+ and React 18+. Near drop-in replacement for `next-themes` - fixes every known bug and adds missing features, including native `useEffectEvent` integration on React 19.2+. Migrating requires changing one import line.
 
 TypeScript 5.9 or newer is required. TypeScript 5.9, 6, and 7 are supported and checked against the published package declarations in CI.
 

--- a/apps/docs/README.md
+++ b/apps/docs/README.md
@@ -1,45 +1,14 @@
-# theme-docs
+# @wrksz/themes documentation
 
-This is a Next.js application generated with
-[Create Fumadocs](https://github.com/fuma-nama/fumadocs).
+This Fumadocs application is the canonical API and examples site for `@wrksz/themes`.
 
-Run development server:
+From the repository root:
 
-```bash
-npm run dev
-# or
-pnpm dev
-# or
-yarn dev
+```sh
+CI=true bun install --frozen-lockfile
+bun run dev:docs
 ```
 
-Open http://localhost:3000 with your browser to see the result.
+Run `bun run test:docs`, `bun run type-check`, and `bun run build:docs` before submitting documentation changes. Content lives in `content/docs`; shared navigation and source configuration live in `src/lib`.
 
-## Explore
-
-In the project, you can see:
-
-- `lib/source.ts`: Code for content source adapter, [`loader()`](https://fumadocs.dev/docs/headless/source-api) provides the interface to access your content.
-- `lib/layout.shared.tsx`: Shared options for layouts, optional but preferred to keep.
-
-| Route                     | Description                                            |
-| ------------------------- | ------------------------------------------------------ |
-| `app/(home)`              | The route group for your landing page and other pages. |
-| `app/docs`                | The documentation layout and pages.                    |
-| `app/api/search/route.ts` | The Route Handler for search.                          |
-
-### Fumadocs MDX
-
-A `source.config.ts` config file has been included, you can customise different options like frontmatter schema.
-
-Read the [Introduction](https://fumadocs.dev/docs/mdx) for further details.
-
-## Learn More
-
-To learn more about Next.js and Fumadocs, take a look at the following
-resources:
-
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js
-  features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
-- [Fumadocs](https://fumadocs.dev) - learn about Fumadocs
+Keep API details here and link to them from README files instead of maintaining duplicate prop tables. Repository-wide contribution and release guidance is in [`../../CONTRIBUTING.md`](../../CONTRIBUTING.md).

--- a/apps/docs/content/docs/api/create-themes.mdx
+++ b/apps/docs/content/docs/api/create-themes.mdx
@@ -111,6 +111,37 @@ export function AuthSection({ children }: { children: React.ReactNode }) {
 
 The configured `themes` tuple remains the source of truth, so the typed provider does not accept a per-use `themes` override. Create another factory if a subtree genuinely needs a different theme union.
 
+## Independent theme dimensions
+
+Every factory owns its own context. You can combine independent mode, palette, typography, or contrast axes without one nested provider hiding another factory's hook:
+
+```tsx title="app/preferences.ts"
+import { createThemes } from "@wrksz/themes/client";
+
+export const mode = createThemes({
+  themes: ["light", "dark"] as const,
+  attribute: "data-mode",
+  storageKey: "mode",
+});
+
+export const palette = createThemes({
+  themes: ["ocean", "forest"] as const,
+  attribute: "data-palette",
+  storageKey: "palette",
+  enableSystem: false,
+});
+```
+
+```tsx
+<mode.ThemeProvider>
+  <palette.ThemeProvider>
+    {children}
+  </palette.ThemeProvider>
+</mode.ThemeProvider>
+```
+
+The resulting attributes are independent, for example `data-mode="dark"` and `data-palette="forest"`. This avoids defining every mode/palette combination as a separate theme.
+
 ## Generic `useTheme<T>()` vs `createThemes`
 
 - Use `createThemes` for shipped app code with one canonical theme configuration.

--- a/apps/docs/content/docs/api/theme-provider.mdx
+++ b/apps/docs/content/docs/api/theme-provider.mdx
@@ -74,6 +74,10 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
 | `followSystem` | `boolean` | `false` | Always follow system preference, ignores stored value on mount |
 | `themeColor` | `string \| Record<string, string>` | - | Update `<meta name="theme-color">` on theme change |
 | `nonce` | `string` | - | CSP nonce for the inline script |
+| `scriptProps` | `ScriptHTMLAttributes<HTMLScriptElement>` | - | Extra attributes for the bootstrap script, such as `data-cfasync="false"` |
+| `onStorageError` | `(error: unknown) => void` | - | Reports unavailable, blocked, or quota-limited storage without interrupting theme updates |
+| `systemThemeMap` | `{ light: string; dark: string } \| Record<string, { light: string; dark: string }>` | - | Serializable custom resolution for system-aware variants |
+| `themeRoot` | `Element \| ShadowRoot` | - | Client-only Shadow DOM/custom root. Use `target` when the root must be themed before hydration |
 | `onThemeChange` | `(theme: string) => void` | - | Called whenever the theme changes. Receives the selected value (may be `"system"`). When system preference changes while theme is `"system"`, fires with the resolved value (`"light"` or `"dark"`). |
 
 ## Security notes
@@ -291,6 +295,26 @@ Unlike `defaultTheme="system"`, which applies the system preference only on firs
   {children}
 </ThemeProvider>
 ```
+
+Use this with your consent manager rather than giving the theme library control over consent:
+
+```tsx
+<ThemeProvider storage={hasPreferenceConsent ? "localStorage" : "none"}>
+  {children}
+</ThemeProvider>
+```
+
+Remove the previous key when consent is revoked if your policy requires deletion; `storage="none"` guarantees no further reads or writes.
+
+### Observe storage failures
+
+```tsx
+<ThemeProvider onStorageError={(error) => reportError(error)}>
+  {children}
+</ThemeProvider>
+```
+
+The selected theme still updates in memory and on the DOM when persistence is unavailable.
 
 ### Meta theme-color
 

--- a/apps/docs/content/docs/examples/data-attribute.mdx
+++ b/apps/docs/content/docs/examples/data-attribute.mdx
@@ -56,3 +56,11 @@ Apply multiple attributes at once by passing an array:
 ```
 
 This sets both the `dark` class and `data-theme="dark"` simultaneously, useful when mixing Tailwind with CSS variable styles.
+
+## Class or data attribute?
+
+- Use `class` when your CSS framework already uses class selectors, or when one theme maps to several utility classes.
+- Use a `data-*` attribute when theme state should be explicit, isolated from unrelated classes, or combined with another independent dimension such as `data-palette`.
+- Selector performance is not a meaningful difference for a root-level theme attribute. Specificity and integration with your existing CSS are the practical concerns.
+
+An attribute array mirrors one theme value to several attributes. For independently controlled values, create separate typed factories with distinct contexts and storage keys.

--- a/apps/docs/content/docs/index.mdx
+++ b/apps/docs/content/docs/index.mdx
@@ -91,7 +91,7 @@ export function ThemeToggle() {
 ## Requirements
 
 - Next.js 16+
-- React 19.2+
+- React 18+ (uses native `useEffectEvent` on React 19.2+)
 
 ## Next steps
 

--- a/apps/docs/content/docs/index.mdx
+++ b/apps/docs/content/docs/index.mdx
@@ -91,7 +91,7 @@ export function ThemeToggle() {
 ## Requirements
 
 - Next.js 16+
-- React 19+
+- React 19.2+
 
 ## Next steps
 

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -6,6 +6,7 @@
 		"build": "bun run --cwd ../../packages/themes build && next build",
 		"dev": "next dev",
 		"start": "next start",
+		"test": "bun test src/__tests__",
 		"types:check": "fumadocs-mdx && next typegen && tsc --noEmit",
 		"postinstall": "fumadocs-mdx",
 		"lint": "biome check",

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -33,7 +33,7 @@
 		"@types/node": "^25.5.0",
 		"@types/react": "^19.2.14",
 		"@types/react-dom": "^19.2.3",
-		"postcss": "^8.5.8",
+		"postcss": "^8.5.26",
 		"tailwindcss": "^4.2.2",
 		"typescript": "^5.9.3"
 	}

--- a/apps/docs/src/__tests__/theme-integration.test.tsx
+++ b/apps/docs/src/__tests__/theme-integration.test.tsx
@@ -1,0 +1,55 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import "../../../../packages/themes/src/__tests__/setup.js";
+import { act, cleanup, fireEvent, render } from "@testing-library/react";
+import { ThemeProvider, useTheme } from "@/components/theme";
+
+(globalThis as unknown as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT = true;
+
+function ThemeProbe() {
+	const { theme, resolvedTheme, setTheme } = useTheme();
+	return (
+		<>
+			<span data-testid="theme">{theme}</span>
+			<span data-testid="resolved-theme">{resolvedTheme}</span>
+			<button type="button" onClick={() => setTheme("dark")}>
+				Dark
+			</button>
+		</>
+	);
+}
+
+beforeEach(() => {
+	document.documentElement.className = "";
+	localStorage.clear();
+	window.matchMedia = () =>
+		({
+			matches: false,
+			addEventListener: () => { },
+			removeEventListener: () => { },
+		}) as unknown as MediaQueryList;
+});
+
+afterEach(() => {
+	cleanup();
+	localStorage.clear();
+});
+
+describe("docs theme integration", () => {
+	test("applies the initial theme and switches through the typed docs module", () => {
+		const view = render(
+			<ThemeProvider>
+				<ThemeProbe />
+			</ThemeProvider>,
+		);
+
+		expect(view.getByTestId("theme").textContent).toBe("system");
+		expect(view.getByTestId("resolved-theme").textContent).toBe("light");
+		expect(document.documentElement.classList.contains("light")).toBe(true);
+
+		act(() => fireEvent.click(view.getByRole("button", { name: "Dark" })));
+
+		expect(view.getByTestId("theme").textContent).toBe("dark");
+		expect(view.getByTestId("resolved-theme").textContent).toBe("dark");
+		expect(document.documentElement.classList.contains("dark")).toBe(true);
+	});
+});

--- a/apps/docs/src/__tests__/theme-integration.test.tsx
+++ b/apps/docs/src/__tests__/theme-integration.test.tsx
@@ -24,8 +24,8 @@ beforeEach(() => {
 	window.matchMedia = () =>
 		({
 			matches: false,
-			addEventListener: () => { },
-			removeEventListener: () => { },
+			addEventListener: () => {},
+			removeEventListener: () => {},
 		}) as unknown as MediaQueryList;
 });
 

--- a/apps/docs/src/app/layout.tsx
+++ b/apps/docs/src/app/layout.tsx
@@ -35,7 +35,7 @@ export const metadata: Metadata = {
 export default function Layout({ children }: LayoutProps<"/">) {
 	return (
 		<html lang="en" className={inter.className} suppressHydrationWarning>
-			<body className="flex flex-col min-h-screen antialiased">
+			<body className="flex flex-col min-h-dvh antialiased">
 				<ThemeProvider {...themeProviderDefaults} themes={appThemes}>
 					<RootProvider>{children}</RootProvider>
 				</ThemeProvider>

--- a/apps/docs/src/app/layout.tsx
+++ b/apps/docs/src/app/layout.tsx
@@ -1,8 +1,10 @@
+import { ThemeProvider } from "@wrksz/themes/next";
 import { RootProvider } from "fumadocs-ui/provider/next";
 import type { Metadata } from "next";
 import "./global.css";
 import { Analytics } from "@vercel/analytics/next";
 import { Inter } from "next/font/google";
+import { appThemes, themeProviderDefaults } from "@/lib/theme-config";
 
 const inter = Inter({
 	subsets: ["latin"],
@@ -34,7 +36,9 @@ export default function Layout({ children }: LayoutProps<"/">) {
 	return (
 		<html lang="en" className={inter.className} suppressHydrationWarning>
 			<body className="flex flex-col min-h-screen antialiased">
-				<RootProvider>{children}</RootProvider>
+				<ThemeProvider {...themeProviderDefaults} themes={appThemes}>
+					<RootProvider>{children}</RootProvider>
+				</ThemeProvider>
 				<Analytics />
 			</body>
 		</html>

--- a/apps/docs/src/components/theme.ts
+++ b/apps/docs/src/components/theme.ts
@@ -3,9 +3,7 @@
 import { createThemes } from "@wrksz/themes/client";
 import { appThemes, themeProviderDefaults } from "@/lib/theme-config";
 
-export const { ThemeProvider, ThemedImage, useTheme, useThemeEffect, useThemeValue } = createThemes(
-	{
-		...themeProviderDefaults,
-		themes: appThemes,
-	},
-);
+export const { ThemeProvider, useTheme } = createThemes({
+	...themeProviderDefaults,
+	themes: appThemes,
+});

--- a/apps/docs/src/components/theme.ts
+++ b/apps/docs/src/components/theme.ts
@@ -1,0 +1,11 @@
+"use client";
+
+import { createThemes } from "@wrksz/themes/client";
+import { appThemes, themeProviderDefaults } from "@/lib/theme-config";
+
+export const { ThemeProvider, ThemedImage, useTheme, useThemeEffect, useThemeValue } = createThemes(
+	{
+		...themeProviderDefaults,
+		themes: appThemes,
+	},
+);

--- a/apps/docs/src/lib/theme-config.ts
+++ b/apps/docs/src/lib/theme-config.ts
@@ -1,0 +1,12 @@
+import type { ThemeProviderProps } from "@wrksz/themes";
+
+export const appThemes = ["light", "dark"] as const;
+export type AppTheme = (typeof appThemes)[number];
+
+export const themeProviderDefaults = {
+	attribute: "class",
+	defaultTheme: "system",
+	enableSystem: true,
+	storage: "localStorage",
+	disableTransitionOnChange: true,
+} satisfies Omit<ThemeProviderProps<AppTheme>, "children" | "themes">;

--- a/apps/next-16-3/package.json
+++ b/apps/next-16-3/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@wrksz/themes": "workspace:*",
-    "next": "16.3.0-preview.8",
+    "next": "16.3.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4"
   },

--- a/bun.lock
+++ b/bun.lock
@@ -692,7 +692,7 @@
 
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
-    "framer-motion": ["framer-motion@12.39.0", "", { "dependencies": { "motion-dom": "^12.39.0", "motion-utils": "^12.39.0", "tslib": "^2.4.0" }, "peerDependencies": { "@emotion/is-prop-valid": "*", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@emotion/is-prop-valid", "react", "react-dom"] }, "sha512-+vnLfzrv0MzjLzNl+nvNvR7jdg3q4cxxjz/YvzfifHl0TREtL00cs1RoMTxs+1PzLiEqZGV6gYsBY0oEAYZ24w=="],
+    "framer-motion": ["framer-motion@12.42.2", "", { "dependencies": { "motion-dom": "^12.42.2", "motion-utils": "^12.39.0", "tslib": "^2.4.0" }, "peerDependencies": { "@emotion/is-prop-valid": "*", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@emotion/is-prop-valid", "react", "react-dom"] }, "sha512-5XY9luDiu0oHfHBjpDthFMh0ES+122w6p/papSJBweMkO8Sn+PW2QaEgRblQBpWFnuvZS5qvarpt/hO2pjGmnw=="],
 
     "fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
 
@@ -906,9 +906,9 @@
 
     "micromark-util-types": ["micromark-util-types@2.0.2", "", {}, "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA=="],
 
-    "motion": ["motion@12.39.0", "", { "dependencies": { "framer-motion": "^12.39.0", "tslib": "^2.4.0" }, "peerDependencies": { "@emotion/is-prop-valid": "*", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@emotion/is-prop-valid", "react", "react-dom"] }, "sha512-H4a+Ze+a9j+/NTla5ezfb/g9vmIOxC+viDj++NGDZyTZkdRKjiOz3kSv6TalRWM8ZmD2y/CfC6TkQc97ybyqSA=="],
+    "motion": ["motion@12.42.2", "", { "dependencies": { "framer-motion": "^12.42.2", "tslib": "^2.4.0" }, "peerDependencies": { "@emotion/is-prop-valid": "*", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@emotion/is-prop-valid", "react", "react-dom"] }, "sha512-Atvv11yUKIid41cVrRBDVX5m8tF8kNpExRSlbpt6APClhDjtwQssgFHhQzejxw7/7YYbjHSPKBVbHo05BuJT5Q=="],
 
-    "motion-dom": ["motion-dom@12.39.0", "", { "dependencies": { "motion-utils": "^12.39.0" } }, "sha512-Xn7aAcGDhco/JZTXOub64UmaYn73C6J1Po7Fk+8EvkJsNGTqfhon6UJY53vJKXW5v5Zl8HrYsVxv6oPXeGoGLQ=="],
+    "motion-dom": ["motion-dom@12.42.2", "", { "dependencies": { "motion-utils": "^12.39.0" } }, "sha512-5gIMWLp/PycBtJRJWRgjxke5n8dlvkSn2DrYW+tr3XcqAZY1xZh6BJyooJXCM8wdfM7wfMjkBJNLge1CKPUIRA=="],
 
     "motion-utils": ["motion-utils@12.39.0", "", {}, "sha512-8nadJAJjTtqRkmRF36FoJTrywK9nnFmnPwnSMyxaOCU7GDjN9RTMJIxx9De8ErM+vpPhMccr/6fo5WciyQLnMQ=="],
 
@@ -1106,8 +1106,6 @@
 
     "fumadocs-mdx/tinyexec": ["tinyexec@1.2.4", "", {}, "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg=="],
 
-    "fumadocs-ui/motion": ["motion@12.42.2", "", { "dependencies": { "framer-motion": "^12.42.2", "tslib": "^2.4.0" }, "peerDependencies": { "@emotion/is-prop-valid": "*", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@emotion/is-prop-valid", "react", "react-dom"] }, "sha512-Atvv11yUKIid41cVrRBDVX5m8tF8kNpExRSlbpt6APClhDjtwQssgFHhQzejxw7/7YYbjHSPKBVbHo05BuJT5Q=="],
-
     "next/postcss": ["postcss@8.4.31", "", { "dependencies": { "nanoid": "^3.3.6", "picocolors": "^1.0.0", "source-map-js": "^1.0.2" } }, "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ=="],
 
     "next-16-3-compat/next": ["next@16.3.0-preview.8", "", { "dependencies": { "@next/env": "16.3.0-preview.8", "@swc/helpers": "0.5.15", "baseline-browser-mapping": "^2.9.19", "caniuse-lite": "^1.0.30001579", "postcss": "8.5.10", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "16.3.0-preview.8", "@next/swc-darwin-x64": "16.3.0-preview.8", "@next/swc-linux-arm64-gnu": "16.3.0-preview.8", "@next/swc-linux-arm64-musl": "16.3.0-preview.8", "@next/swc-linux-x64-gnu": "16.3.0-preview.8", "@next/swc-linux-x64-musl": "16.3.0-preview.8", "@next/swc-win32-arm64-msvc": "16.3.0-preview.8", "@next/swc-win32-x64-msvc": "16.3.0-preview.8", "sharp": "^0.35.3" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.51.1", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-c9CF1GAZnpB7iwZWCnPdSPfdrmGkvr+lGqcRuH++EIYFxb4Mk6EIve13ExuO4ghbhayQVGyP+hY8BocnQ/aHbA=="],
@@ -1119,8 +1117,6 @@
     "theme-docs/next": ["next@16.2.11", "", { "dependencies": { "@next/env": "16.2.11", "@swc/helpers": "0.5.15", "baseline-browser-mapping": "^2.9.19", "caniuse-lite": "^1.0.30001579", "postcss": "8.4.31", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "16.2.11", "@next/swc-darwin-x64": "16.2.11", "@next/swc-linux-arm64-gnu": "16.2.11", "@next/swc-linux-arm64-musl": "16.2.11", "@next/swc-linux-x64-gnu": "16.2.11", "@next/swc-linux-x64-musl": "16.2.11", "@next/swc-win32-arm64-msvc": "16.2.11", "@next/swc-win32-x64-msvc": "16.2.11", "sharp": "^0.34.5" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.51.1", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-B339zaqbyK8cmxhoAvLrcwoabwCP1wz21zSzfqxqXAemTu2BXnH7tQnfcglKv1vnMUIDBc+Hth7XODQriTZiRQ=="],
 
     "yuku-ast/@yuku-toolchain/types": ["@yuku-toolchain/types@0.6.8", "", {}, "sha512-AbUd1775RVkOxJkh8hkldIWoU6kRMTCsZFSZq8Ny53q7GkbaVe5UCfleNZ3RWCoz/ZKE8qwfeB7Cj0xqhLWsKA=="],
-
-    "fumadocs-ui/motion/framer-motion": ["framer-motion@12.42.2", "", { "dependencies": { "motion-dom": "^12.42.2", "motion-utils": "^12.39.0", "tslib": "^2.4.0" }, "peerDependencies": { "@emotion/is-prop-valid": "*", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@emotion/is-prop-valid", "react", "react-dom"] }, "sha512-5XY9luDiu0oHfHBjpDthFMh0ES+122w6p/papSJBweMkO8Sn+PW2QaEgRblQBpWFnuvZS5qvarpt/hO2pjGmnw=="],
 
     "next-16-3-compat/next/@next/env": ["@next/env@16.3.0-preview.8", "", {}, "sha512-OUjzx/+GzS6FwtpBVSA2Y5U+XqWBcSQwXr/kJrTrdHcwoQFVATof0RSBFj5cjBy9rMwezGkCL6/HjO2WdO+dQA=="],
 
@@ -1161,7 +1157,5 @@
     "theme-docs/next/@next/swc-win32-x64-msvc": ["@next/swc-win32-x64-msvc@16.2.11", "", { "os": "win32", "cpu": "x64" }, "sha512-md8CLNggS1Dx9pUgApzps5uAf+N8GN9xywzmNx9vHAWo94HtBwCCqkSnhIrdfQe83Dhz8Lfo/20Nb1Zxal092w=="],
 
     "theme-docs/next/postcss": ["postcss@8.4.31", "", { "dependencies": { "nanoid": "^3.3.6", "picocolors": "^1.0.0", "source-map-js": "^1.0.2" } }, "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ=="],
-
-    "fumadocs-ui/motion/framer-motion/motion-dom": ["motion-dom@12.42.2", "", { "dependencies": { "motion-utils": "^12.39.0" } }, "sha512-5gIMWLp/PycBtJRJWRgjxke5n8dlvkSn2DrYW+tr3XcqAZY1xZh6BJyooJXCM8wdfM7wfMjkBJNLge1CKPUIRA=="],
   }
 }

--- a/bun.lock
+++ b/bun.lock
@@ -692,7 +692,7 @@
 
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
-    "framer-motion": ["framer-motion@12.42.2", "", { "dependencies": { "motion-dom": "^12.42.2", "motion-utils": "^12.39.0", "tslib": "^2.4.0" }, "peerDependencies": { "@emotion/is-prop-valid": "*", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@emotion/is-prop-valid", "react", "react-dom"] }, "sha512-5XY9luDiu0oHfHBjpDthFMh0ES+122w6p/papSJBweMkO8Sn+PW2QaEgRblQBpWFnuvZS5qvarpt/hO2pjGmnw=="],
+    "framer-motion": ["framer-motion@12.39.0", "", { "dependencies": { "motion-dom": "^12.39.0", "motion-utils": "^12.39.0", "tslib": "^2.4.0" }, "peerDependencies": { "@emotion/is-prop-valid": "*", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@emotion/is-prop-valid", "react", "react-dom"] }, "sha512-+vnLfzrv0MzjLzNl+nvNvR7jdg3q4cxxjz/YvzfifHl0TREtL00cs1RoMTxs+1PzLiEqZGV6gYsBY0oEAYZ24w=="],
 
     "fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
 
@@ -906,9 +906,9 @@
 
     "micromark-util-types": ["micromark-util-types@2.0.2", "", {}, "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA=="],
 
-    "motion": ["motion@12.42.2", "", { "dependencies": { "framer-motion": "^12.42.2", "tslib": "^2.4.0" }, "peerDependencies": { "@emotion/is-prop-valid": "*", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@emotion/is-prop-valid", "react", "react-dom"] }, "sha512-Atvv11yUKIid41cVrRBDVX5m8tF8kNpExRSlbpt6APClhDjtwQssgFHhQzejxw7/7YYbjHSPKBVbHo05BuJT5Q=="],
+    "motion": ["motion@12.39.0", "", { "dependencies": { "framer-motion": "^12.39.0", "tslib": "^2.4.0" }, "peerDependencies": { "@emotion/is-prop-valid": "*", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@emotion/is-prop-valid", "react", "react-dom"] }, "sha512-H4a+Ze+a9j+/NTla5ezfb/g9vmIOxC+viDj++NGDZyTZkdRKjiOz3kSv6TalRWM8ZmD2y/CfC6TkQc97ybyqSA=="],
 
-    "motion-dom": ["motion-dom@12.42.2", "", { "dependencies": { "motion-utils": "^12.39.0" } }, "sha512-5gIMWLp/PycBtJRJWRgjxke5n8dlvkSn2DrYW+tr3XcqAZY1xZh6BJyooJXCM8wdfM7wfMjkBJNLge1CKPUIRA=="],
+    "motion-dom": ["motion-dom@12.39.0", "", { "dependencies": { "motion-utils": "^12.39.0" } }, "sha512-Xn7aAcGDhco/JZTXOub64UmaYn73C6J1Po7Fk+8EvkJsNGTqfhon6UJY53vJKXW5v5Zl8HrYsVxv6oPXeGoGLQ=="],
 
     "motion-utils": ["motion-utils@12.39.0", "", {}, "sha512-8nadJAJjTtqRkmRF36FoJTrywK9nnFmnPwnSMyxaOCU7GDjN9RTMJIxx9De8ErM+vpPhMccr/6fo5WciyQLnMQ=="],
 
@@ -1106,6 +1106,8 @@
 
     "fumadocs-mdx/tinyexec": ["tinyexec@1.2.4", "", {}, "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg=="],
 
+    "fumadocs-ui/motion": ["motion@12.42.2", "", { "dependencies": { "framer-motion": "^12.42.2", "tslib": "^2.4.0" }, "peerDependencies": { "@emotion/is-prop-valid": "*", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@emotion/is-prop-valid", "react", "react-dom"] }, "sha512-Atvv11yUKIid41cVrRBDVX5m8tF8kNpExRSlbpt6APClhDjtwQssgFHhQzejxw7/7YYbjHSPKBVbHo05BuJT5Q=="],
+
     "next/postcss": ["postcss@8.4.31", "", { "dependencies": { "nanoid": "^3.3.6", "picocolors": "^1.0.0", "source-map-js": "^1.0.2" } }, "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ=="],
 
     "next-16-3-compat/next": ["next@16.3.0-preview.8", "", { "dependencies": { "@next/env": "16.3.0-preview.8", "@swc/helpers": "0.5.15", "baseline-browser-mapping": "^2.9.19", "caniuse-lite": "^1.0.30001579", "postcss": "8.5.10", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "16.3.0-preview.8", "@next/swc-darwin-x64": "16.3.0-preview.8", "@next/swc-linux-arm64-gnu": "16.3.0-preview.8", "@next/swc-linux-arm64-musl": "16.3.0-preview.8", "@next/swc-linux-x64-gnu": "16.3.0-preview.8", "@next/swc-linux-x64-musl": "16.3.0-preview.8", "@next/swc-win32-arm64-msvc": "16.3.0-preview.8", "@next/swc-win32-x64-msvc": "16.3.0-preview.8", "sharp": "^0.35.3" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.51.1", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-c9CF1GAZnpB7iwZWCnPdSPfdrmGkvr+lGqcRuH++EIYFxb4Mk6EIve13ExuO4ghbhayQVGyP+hY8BocnQ/aHbA=="],
@@ -1117,6 +1119,8 @@
     "theme-docs/next": ["next@16.2.11", "", { "dependencies": { "@next/env": "16.2.11", "@swc/helpers": "0.5.15", "baseline-browser-mapping": "^2.9.19", "caniuse-lite": "^1.0.30001579", "postcss": "8.4.31", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "16.2.11", "@next/swc-darwin-x64": "16.2.11", "@next/swc-linux-arm64-gnu": "16.2.11", "@next/swc-linux-arm64-musl": "16.2.11", "@next/swc-linux-x64-gnu": "16.2.11", "@next/swc-linux-x64-musl": "16.2.11", "@next/swc-win32-arm64-msvc": "16.2.11", "@next/swc-win32-x64-msvc": "16.2.11", "sharp": "^0.34.5" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.51.1", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-B339zaqbyK8cmxhoAvLrcwoabwCP1wz21zSzfqxqXAemTu2BXnH7tQnfcglKv1vnMUIDBc+Hth7XODQriTZiRQ=="],
 
     "yuku-ast/@yuku-toolchain/types": ["@yuku-toolchain/types@0.6.8", "", {}, "sha512-AbUd1775RVkOxJkh8hkldIWoU6kRMTCsZFSZq8Ny53q7GkbaVe5UCfleNZ3RWCoz/ZKE8qwfeB7Cj0xqhLWsKA=="],
+
+    "fumadocs-ui/motion/framer-motion": ["framer-motion@12.42.2", "", { "dependencies": { "motion-dom": "^12.42.2", "motion-utils": "^12.39.0", "tslib": "^2.4.0" }, "peerDependencies": { "@emotion/is-prop-valid": "*", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@emotion/is-prop-valid", "react", "react-dom"] }, "sha512-5XY9luDiu0oHfHBjpDthFMh0ES+122w6p/papSJBweMkO8Sn+PW2QaEgRblQBpWFnuvZS5qvarpt/hO2pjGmnw=="],
 
     "next-16-3-compat/next/@next/env": ["@next/env@16.3.0-preview.8", "", {}, "sha512-OUjzx/+GzS6FwtpBVSA2Y5U+XqWBcSQwXr/kJrTrdHcwoQFVATof0RSBFj5cjBy9rMwezGkCL6/HjO2WdO+dQA=="],
 
@@ -1157,5 +1161,7 @@
     "theme-docs/next/@next/swc-win32-x64-msvc": ["@next/swc-win32-x64-msvc@16.2.11", "", { "os": "win32", "cpu": "x64" }, "sha512-md8CLNggS1Dx9pUgApzps5uAf+N8GN9xywzmNx9vHAWo94HtBwCCqkSnhIrdfQe83Dhz8Lfo/20Nb1Zxal092w=="],
 
     "theme-docs/next/postcss": ["postcss@8.4.31", "", { "dependencies": { "nanoid": "^3.3.6", "picocolors": "^1.0.0", "source-map-js": "^1.0.2" } }, "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ=="],
+
+    "fumadocs-ui/motion/framer-motion/motion-dom": ["motion-dom@12.42.2", "", { "dependencies": { "motion-utils": "^12.39.0" } }, "sha512-5gIMWLp/PycBtJRJWRgjxke5n8dlvkSn2DrYW+tr3XcqAZY1xZh6BJyooJXCM8wdfM7wfMjkBJNLge1CKPUIRA=="],
   }
 }

--- a/bun.lock
+++ b/bun.lock
@@ -13,7 +13,7 @@
         "bunup": "^0.16.31",
         "happy-dom": "^20.11.1",
         "lefthook": "^2.1.4",
-        "next": ">=16.0.0",
+        "next": ">=16.2.11",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
         "typescript": "^5.9.3",
@@ -43,7 +43,7 @@
         "@types/node": "^25.5.0",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
-        "postcss": "^8.5.8",
+        "postcss": "^8.5.26",
         "tailwindcss": "^4.2.2",
         "typescript": "^5.9.3",
       },
@@ -52,7 +52,7 @@
       "name": "next-16-3-compat",
       "dependencies": {
         "@wrksz/themes": "workspace:*",
-        "next": "16.3.0-preview.8",
+        "next": "16.3.0",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
       },
@@ -79,6 +79,8 @@
     },
   },
   "overrides": {
+    "nanoid": "3.3.18",
+    "postcss": "8.5.26",
     "sharp": "0.35.3",
   },
   "packages": {
@@ -260,23 +262,23 @@
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.4", "", { "dependencies": { "@tybys/wasm-util": "^0.10.1" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow=="],
 
-    "@next/env": ["@next/env@16.2.6", "", {}, "sha512-gd8HoHN4ufj73WmR3JmVolrpJR47ILK6LouP5xElPglaVxir6e1a7VzvTvDWkOoPXT9rkkTzyCxBu4yeZfZwcw=="],
+    "@next/env": ["@next/env@16.2.11", "", {}, "sha512-0do5A3BJ2gxWr0ZCMcD6BhW+e595jyxdTl3rXTS6lOtD8ektMiW6CO+EPwt1Eca1DBnm90r/7GdiKWBKxH++DA=="],
 
-    "@next/swc-darwin-arm64": ["@next/swc-darwin-arm64@16.2.6", "", { "os": "darwin", "cpu": "arm64" }, "sha512-ZJGkkcNfYgrrMkqOdZ7zoLa1TOy0qpcMfk/z4Mh/FKUz40gVO+HNQWqmLxf67Z5WB64DRp0dhEbyHfel+6sJUg=="],
+    "@next/swc-darwin-arm64": ["@next/swc-darwin-arm64@16.2.11", "", { "os": "darwin", "cpu": "arm64" }, "sha512-wryL4pjKmDwGv2ox6+GZDFxvmtSRLqApBR8kL1j4+vhB7Z5vJC/zAnXpiR9Xkfzl0AS8WLMnsuGV/UKI67/rrw=="],
 
-    "@next/swc-darwin-x64": ["@next/swc-darwin-x64@16.2.6", "", { "os": "darwin", "cpu": "x64" }, "sha512-v/YLBHIY132Ced3puBJ7YJKw1lqsCrgcNo2aRJlCEyQrrCeRJlvGlnmxhPxNQI3KE3N1DN5r9TPNPvka3nq5RQ=="],
+    "@next/swc-darwin-x64": ["@next/swc-darwin-x64@16.2.11", "", { "os": "darwin", "cpu": "x64" }, "sha512-aZl2j4f/fLyjQvOhv0Oe9UaMAQHolYpKhctsoYzplSumKJKPUmgjcf6545aBtysLTcu994TREd0+pSgNE4ohmg=="],
 
-    "@next/swc-linux-arm64-gnu": ["@next/swc-linux-arm64-gnu@16.2.6", "", { "os": "linux", "cpu": "arm64" }, "sha512-RPOvqlYBbcQjkz9VQQDZ2T2bARIjXZV1KFlt+V2Mr6SW/e4I9fcKsaA0hdyf2FHoTlsV2xnBd5Y912rP/1Ce6w=="],
+    "@next/swc-linux-arm64-gnu": ["@next/swc-linux-arm64-gnu@16.2.11", "", { "os": "linux", "cpu": "arm64" }, "sha512-5jEriyEnH/LWFy27L2ZG0XaLlyEJIjhsImEsiS9P563PKEVp2BVups/xfOucIrsvVntp11oNcZwjHvaDPYVB5g=="],
 
-    "@next/swc-linux-arm64-musl": ["@next/swc-linux-arm64-musl@16.2.6", "", { "os": "linux", "cpu": "arm64" }, "sha512-URUTu1+dMkxJsPFgm+OeEvq9wf5sujw0EvgYy80TDGHTSLTnIHeqb0Eu8A3sC95IRgjejQL+kC4mw+4yPxiAXA=="],
+    "@next/swc-linux-arm64-musl": ["@next/swc-linux-arm64-musl@16.2.11", "", { "os": "linux", "cpu": "arm64" }, "sha512-eIjcpx2fnnFSSkZDbTxy74KnokUXDjfoLClpWelfgHLf621aTqswhwXQ7GkD5K5rplrS6LZ/Bj+mVuvzluBOEg=="],
 
-    "@next/swc-linux-x64-gnu": ["@next/swc-linux-x64-gnu@16.2.6", "", { "os": "linux", "cpu": "x64" }, "sha512-DOj182mPV8G3UkrayLoREM5YEYI+Dk5wv7Ox9xl1fFibAELEsFD0lDPfHIeILlutMMfdyhlzYPELG3peuKaurw=="],
+    "@next/swc-linux-x64-gnu": ["@next/swc-linux-x64-gnu@16.2.11", "", { "os": "linux", "cpu": "x64" }, "sha512-8WgzpaWMs46qJT9kiV47cje86L0x/Mu9t8/Gwj+pnbgW3rETVfCnaScPjlYUwNScpOozdcIMHWmAvuZJUonR2w=="],
 
-    "@next/swc-linux-x64-musl": ["@next/swc-linux-x64-musl@16.2.6", "", { "os": "linux", "cpu": "x64" }, "sha512-HKQ5SP/V/ub73UvF7n/zeJlxk2kLmtL7Wzrg4WfmkjmNos5onJ2tKu7yZOPdL18A6Svfn3max29ym+ry7NkK4g=="],
+    "@next/swc-linux-x64-musl": ["@next/swc-linux-x64-musl@16.2.11", "", { "os": "linux", "cpu": "x64" }, "sha512-I3UgPds7G4ZYnTb/H+5GBGuUT2DhAk6j0mL6A4s63RjFs74wB2hOWP0vaxsK+3NJraExt3eYEPQ/UtT0x/64Nw=="],
 
-    "@next/swc-win32-arm64-msvc": ["@next/swc-win32-arm64-msvc@16.2.6", "", { "os": "win32", "cpu": "arm64" }, "sha512-LZXpTlPyS5v7HhSmnvsLGP3iIYgYOBnc8r8ArlT55sGHV89bR2HlDdBjWQ+PY6SJMmk8TuVGFuxalnP3k/0Dwg=="],
+    "@next/swc-win32-arm64-msvc": ["@next/swc-win32-arm64-msvc@16.2.11", "", { "os": "win32", "cpu": "arm64" }, "sha512-n89CjtcThnjrwgJMAiI5xbqwLY51zvwC9tSlArmVndAJLYVl9T9UAdlkXTmZvE++idoXe8KdglQlhNRdUp1c6g=="],
 
-    "@next/swc-win32-x64-msvc": ["@next/swc-win32-x64-msvc@16.2.6", "", { "os": "win32", "cpu": "x64" }, "sha512-F0+4i0h9J6C4eE3EAPWsoCk7UW/dbzOjyzxY0qnDUOYFu6FFmdZ6l97/XdV3/Nz3VYyO7UWjyEJUXkGqcoXfMA=="],
+    "@next/swc-win32-x64-msvc": ["@next/swc-win32-x64-msvc@16.2.11", "", { "os": "win32", "cpu": "x64" }, "sha512-md8CLNggS1Dx9pUgApzps5uAf+N8GN9xywzmNx9vHAWo94HtBwCCqkSnhIrdfQe83Dhz8Lfo/20Nb1Zxal092w=="],
 
     "@orama/orama": ["@orama/orama@3.1.18", "", {}, "sha512-a61ljmRVVyG5MC/698C8/FfFDw5a8LOIvyOLW5fztgUXqUpc1jOfQzOitSCbge657OgXXThmY3Tk8fpiDb4UcA=="],
 
@@ -914,9 +916,9 @@
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
-    "nanoid": ["nanoid@3.3.12", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ=="],
+    "nanoid": ["nanoid@3.3.18", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w=="],
 
-    "next": ["next@16.2.6", "", { "dependencies": { "@next/env": "16.2.6", "@swc/helpers": "0.5.15", "baseline-browser-mapping": "^2.9.19", "caniuse-lite": "^1.0.30001579", "postcss": "8.4.31", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "16.2.6", "@next/swc-darwin-x64": "16.2.6", "@next/swc-linux-arm64-gnu": "16.2.6", "@next/swc-linux-arm64-musl": "16.2.6", "@next/swc-linux-x64-gnu": "16.2.6", "@next/swc-linux-x64-musl": "16.2.6", "@next/swc-win32-arm64-msvc": "16.2.6", "@next/swc-win32-x64-msvc": "16.2.6", "sharp": "^0.34.5" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.51.1", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-qOVgKJg1+At15NpeUP+eJgCHvTCgXsogweq87Ri/Ix7PkqQHg4sdaXmSFqKlgaIXE4kW0g25LE68W87UANlHtw=="],
+    "next": ["next@16.2.11", "", { "dependencies": { "@next/env": "16.2.11", "@swc/helpers": "0.5.15", "baseline-browser-mapping": "^2.9.19", "caniuse-lite": "^1.0.30001579", "postcss": "8.4.31", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "16.2.11", "@next/swc-darwin-x64": "16.2.11", "@next/swc-linux-arm64-gnu": "16.2.11", "@next/swc-linux-arm64-musl": "16.2.11", "@next/swc-linux-x64-gnu": "16.2.11", "@next/swc-linux-x64-musl": "16.2.11", "@next/swc-win32-arm64-msvc": "16.2.11", "@next/swc-win32-x64-msvc": "16.2.11", "sharp": "^0.34.5" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.51.1", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-B339zaqbyK8cmxhoAvLrcwoabwCP1wz21zSzfqxqXAemTu2BXnH7tQnfcglKv1vnMUIDBc+Hth7XODQriTZiRQ=="],
 
     "next-16-3-compat": ["next-16-3-compat@workspace:apps/next-16-3"],
 
@@ -944,7 +946,7 @@
 
     "playwright-core": ["playwright-core@1.61.1", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg=="],
 
-    "postcss": ["postcss@8.5.15", "", { "dependencies": { "nanoid": "^3.3.12", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A=="],
+    "postcss": ["postcss@8.5.26", "", { "dependencies": { "nanoid": "^3.3.17", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ=="],
 
     "pretty-format": ["pretty-format@27.5.1", "", { "dependencies": { "ansi-regex": "^5.0.1", "ansi-styles": "^5.0.0", "react-is": "^17.0.1" } }, "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ=="],
 
@@ -1106,56 +1108,30 @@
 
     "fumadocs-mdx/tinyexec": ["tinyexec@1.2.4", "", {}, "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg=="],
 
-    "next/postcss": ["postcss@8.4.31", "", { "dependencies": { "nanoid": "^3.3.6", "picocolors": "^1.0.0", "source-map-js": "^1.0.2" } }, "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ=="],
-
-    "next-16-3-compat/next": ["next@16.3.0-preview.8", "", { "dependencies": { "@next/env": "16.3.0-preview.8", "@swc/helpers": "0.5.15", "baseline-browser-mapping": "^2.9.19", "caniuse-lite": "^1.0.30001579", "postcss": "8.5.10", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "16.3.0-preview.8", "@next/swc-darwin-x64": "16.3.0-preview.8", "@next/swc-linux-arm64-gnu": "16.3.0-preview.8", "@next/swc-linux-arm64-musl": "16.3.0-preview.8", "@next/swc-linux-x64-gnu": "16.3.0-preview.8", "@next/swc-linux-x64-musl": "16.3.0-preview.8", "@next/swc-win32-arm64-msvc": "16.3.0-preview.8", "@next/swc-win32-x64-msvc": "16.3.0-preview.8", "sharp": "^0.35.3" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.51.1", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-c9CF1GAZnpB7iwZWCnPdSPfdrmGkvr+lGqcRuH++EIYFxb4Mk6EIve13ExuO4ghbhayQVGyP+hY8BocnQ/aHbA=="],
+    "next-16-3-compat/next": ["next@16.3.0", "", { "dependencies": { "@next/env": "16.3.0", "@swc/helpers": "0.5.15", "baseline-browser-mapping": "^2.9.19", "caniuse-lite": "^1.0.30001579", "postcss": "8.5.23", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "16.3.0", "@next/swc-darwin-x64": "16.3.0", "@next/swc-linux-arm64-gnu": "16.3.0", "@next/swc-linux-arm64-musl": "16.3.0", "@next/swc-linux-x64-gnu": "16.3.0", "@next/swc-linux-x64-musl": "16.3.0", "@next/swc-win32-arm64-msvc": "16.3.0", "@next/swc-win32-x64-msvc": "16.3.0", "sharp": "^0.35.3" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.51.1", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-NEdGOzH+08eTXMUp9UYkA99Nhi5N6Thrhc1jgFOQgfgnGK/dA2hRwBpXep+exdFQrnwlRf/3Wixyp8lLBUpE2A=="],
 
     "parse-entities/@types/unist": ["@types/unist@2.0.11", "", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
 
     "parse5/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
 
-    "theme-docs/next": ["next@16.2.11", "", { "dependencies": { "@next/env": "16.2.11", "@swc/helpers": "0.5.15", "baseline-browser-mapping": "^2.9.19", "caniuse-lite": "^1.0.30001579", "postcss": "8.4.31", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "16.2.11", "@next/swc-darwin-x64": "16.2.11", "@next/swc-linux-arm64-gnu": "16.2.11", "@next/swc-linux-arm64-musl": "16.2.11", "@next/swc-linux-x64-gnu": "16.2.11", "@next/swc-linux-x64-musl": "16.2.11", "@next/swc-win32-arm64-msvc": "16.2.11", "@next/swc-win32-x64-msvc": "16.2.11", "sharp": "^0.34.5" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.51.1", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-B339zaqbyK8cmxhoAvLrcwoabwCP1wz21zSzfqxqXAemTu2BXnH7tQnfcglKv1vnMUIDBc+Hth7XODQriTZiRQ=="],
-
     "yuku-ast/@yuku-toolchain/types": ["@yuku-toolchain/types@0.6.8", "", {}, "sha512-AbUd1775RVkOxJkh8hkldIWoU6kRMTCsZFSZq8Ny53q7GkbaVe5UCfleNZ3RWCoz/ZKE8qwfeB7Cj0xqhLWsKA=="],
 
-    "next-16-3-compat/next/@next/env": ["@next/env@16.3.0-preview.8", "", {}, "sha512-OUjzx/+GzS6FwtpBVSA2Y5U+XqWBcSQwXr/kJrTrdHcwoQFVATof0RSBFj5cjBy9rMwezGkCL6/HjO2WdO+dQA=="],
+    "next-16-3-compat/next/@next/env": ["@next/env@16.3.0", "", {}, "sha512-o9r1S0BNiNreHP9Vs+Qnqd9kviDkJh8xIACY7UFZSmiGbbQRzPBBosvHzAU4TULHOIuOj/18RSsyz2qrREmIFw=="],
 
-    "next-16-3-compat/next/@next/swc-darwin-arm64": ["@next/swc-darwin-arm64@16.3.0-preview.8", "", { "os": "darwin", "cpu": "arm64" }, "sha512-zCzL322QKv1xIPV+2atT75awK9YgceZllw2QWGTqW9nDZ/nuaVaRdWVuh3+Uy+nPnDawfBv3Mn9ANEMVh6QSEg=="],
+    "next-16-3-compat/next/@next/swc-darwin-arm64": ["@next/swc-darwin-arm64@16.3.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-55hpqq18bEVAlxedlTt3tFqZmKg2nUXT1kn1G/BGEy0R13h3LwtwHPVzzjG6P4LLeOHE32PFDQUVaJEWvBEZBw=="],
 
-    "next-16-3-compat/next/@next/swc-darwin-x64": ["@next/swc-darwin-x64@16.3.0-preview.8", "", { "os": "darwin", "cpu": "x64" }, "sha512-Vbnekjyb60VcypFxzewH7I2bNY7ajSf811bxoJpJ0eV6ASQh+5yp99aOAsTXtVrmd/WEGdtW/qVaIKQN26lHAw=="],
+    "next-16-3-compat/next/@next/swc-darwin-x64": ["@next/swc-darwin-x64@16.3.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-SOi96kSaF5T+0wW4koiM1bWzSPwjzTesC1p3df+FjdOi5LIQkBK/blxh7HdoKnNuI4PURF1OO7TZqtfnbWDSgw=="],
 
-    "next-16-3-compat/next/@next/swc-linux-arm64-gnu": ["@next/swc-linux-arm64-gnu@16.3.0-preview.8", "", { "os": "linux", "cpu": "arm64" }, "sha512-ErpN+467Gom0TXEz1MLN9iM0vOmERiz9kQu5adCXuFlPGKd4qhDqq9JHVcA+v9zDLCL/CYVxdTwK4H39UTDTig=="],
+    "next-16-3-compat/next/@next/swc-linux-arm64-gnu": ["@next/swc-linux-arm64-gnu@16.3.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-P0gZAoPMF4dyTRzhmkV4PrqVzSOB6t4mC1oI3c4dqijJ+OVEVx5clIXAKR4/uQpsqw2KKM/0D5tVumcR2r5blg=="],
 
-    "next-16-3-compat/next/@next/swc-linux-arm64-musl": ["@next/swc-linux-arm64-musl@16.3.0-preview.8", "", { "os": "linux", "cpu": "arm64" }, "sha512-5YIeE8mteSbOOmFWGVoc+ls373pQ+Sj6bGkEFZlMvU37xSaP4cw30M9r3wbCh0TiKHdlV3HwuaTeykEM3eAh3w=="],
+    "next-16-3-compat/next/@next/swc-linux-arm64-musl": ["@next/swc-linux-arm64-musl@16.3.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-tXXGKJw0m37O0eKJARVTX/TheKPhz0QFVtVVZXmOig+9YKLQOSP6hvf2pxv5DO7CLEJyTHx3Pg043CDQkv1G4Q=="],
 
-    "next-16-3-compat/next/@next/swc-linux-x64-gnu": ["@next/swc-linux-x64-gnu@16.3.0-preview.8", "", { "os": "linux", "cpu": "x64" }, "sha512-MBvZ/lXxG00C69hIv58gWq0CuabFRl1sxud6YHuBYouqkdPWDA3dgfFxv1WWxD1U4I70H+CH3Hpp/niaGmcqGg=="],
+    "next-16-3-compat/next/@next/swc-linux-x64-gnu": ["@next/swc-linux-x64-gnu@16.3.0", "", { "os": "linux", "cpu": "x64" }, "sha512-pjGxK5EY7yWml78ALejFkWmgHsU7wbFQrISiugpH6FbUJhgEvw3xFZ/EBAtLl7QtL0WdQKiG9eWJ3mOKGTukHw=="],
 
-    "next-16-3-compat/next/@next/swc-linux-x64-musl": ["@next/swc-linux-x64-musl@16.3.0-preview.8", "", { "os": "linux", "cpu": "x64" }, "sha512-OpOhuV8Ujvay6dSTLJaoQk+t3MMRx1EidH3dpL8iezvuVsrFDHrsKxSVZaouqDgg8v9Res43AisI3EiKv6LESw=="],
+    "next-16-3-compat/next/@next/swc-linux-x64-musl": ["@next/swc-linux-x64-musl@16.3.0", "", { "os": "linux", "cpu": "x64" }, "sha512-sjo++Xx+lomlPs3HRsHWhVDyGG6ms1kGW5EtHLERdII8AyG1i+f6aq68xHREO6AEMlhjTNEWBSmfJfqm9orf7g=="],
 
-    "next-16-3-compat/next/@next/swc-win32-arm64-msvc": ["@next/swc-win32-arm64-msvc@16.3.0-preview.8", "", { "os": "win32", "cpu": "arm64" }, "sha512-c+rZGOvBT+0D3sthh8kgxfQToJA0p0athbuDDm21WuszFtm7TpPa23a+H4J0x4d9ehrE19O+2d2M9PoB17N6wA=="],
+    "next-16-3-compat/next/@next/swc-win32-arm64-msvc": ["@next/swc-win32-arm64-msvc@16.3.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-C5JSgiO54wURdaxdEUIXqkz04uMqC9UmPX1gtDrV/5Tf1UowdWYI8uA5hfFbPolTlp0q4KZ60xlHePNibf0VIw=="],
 
-    "next-16-3-compat/next/@next/swc-win32-x64-msvc": ["@next/swc-win32-x64-msvc@16.3.0-preview.8", "", { "os": "win32", "cpu": "x64" }, "sha512-M4s+BypigoOg3mW9ZOXmyrLUaFjetqPHqdqMn7MU+AiawP/gVL7cbwp4aWP2EeObMyYlYtLMKiLyR9sYYSAY9w=="],
-
-    "next-16-3-compat/next/postcss": ["postcss@8.5.10", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ=="],
-
-    "theme-docs/next/@next/env": ["@next/env@16.2.11", "", {}, "sha512-0do5A3BJ2gxWr0ZCMcD6BhW+e595jyxdTl3rXTS6lOtD8ektMiW6CO+EPwt1Eca1DBnm90r/7GdiKWBKxH++DA=="],
-
-    "theme-docs/next/@next/swc-darwin-arm64": ["@next/swc-darwin-arm64@16.2.11", "", { "os": "darwin", "cpu": "arm64" }, "sha512-wryL4pjKmDwGv2ox6+GZDFxvmtSRLqApBR8kL1j4+vhB7Z5vJC/zAnXpiR9Xkfzl0AS8WLMnsuGV/UKI67/rrw=="],
-
-    "theme-docs/next/@next/swc-darwin-x64": ["@next/swc-darwin-x64@16.2.11", "", { "os": "darwin", "cpu": "x64" }, "sha512-aZl2j4f/fLyjQvOhv0Oe9UaMAQHolYpKhctsoYzplSumKJKPUmgjcf6545aBtysLTcu994TREd0+pSgNE4ohmg=="],
-
-    "theme-docs/next/@next/swc-linux-arm64-gnu": ["@next/swc-linux-arm64-gnu@16.2.11", "", { "os": "linux", "cpu": "arm64" }, "sha512-5jEriyEnH/LWFy27L2ZG0XaLlyEJIjhsImEsiS9P563PKEVp2BVups/xfOucIrsvVntp11oNcZwjHvaDPYVB5g=="],
-
-    "theme-docs/next/@next/swc-linux-arm64-musl": ["@next/swc-linux-arm64-musl@16.2.11", "", { "os": "linux", "cpu": "arm64" }, "sha512-eIjcpx2fnnFSSkZDbTxy74KnokUXDjfoLClpWelfgHLf621aTqswhwXQ7GkD5K5rplrS6LZ/Bj+mVuvzluBOEg=="],
-
-    "theme-docs/next/@next/swc-linux-x64-gnu": ["@next/swc-linux-x64-gnu@16.2.11", "", { "os": "linux", "cpu": "x64" }, "sha512-8WgzpaWMs46qJT9kiV47cje86L0x/Mu9t8/Gwj+pnbgW3rETVfCnaScPjlYUwNScpOozdcIMHWmAvuZJUonR2w=="],
-
-    "theme-docs/next/@next/swc-linux-x64-musl": ["@next/swc-linux-x64-musl@16.2.11", "", { "os": "linux", "cpu": "x64" }, "sha512-I3UgPds7G4ZYnTb/H+5GBGuUT2DhAk6j0mL6A4s63RjFs74wB2hOWP0vaxsK+3NJraExt3eYEPQ/UtT0x/64Nw=="],
-
-    "theme-docs/next/@next/swc-win32-arm64-msvc": ["@next/swc-win32-arm64-msvc@16.2.11", "", { "os": "win32", "cpu": "arm64" }, "sha512-n89CjtcThnjrwgJMAiI5xbqwLY51zvwC9tSlArmVndAJLYVl9T9UAdlkXTmZvE++idoXe8KdglQlhNRdUp1c6g=="],
-
-    "theme-docs/next/@next/swc-win32-x64-msvc": ["@next/swc-win32-x64-msvc@16.2.11", "", { "os": "win32", "cpu": "x64" }, "sha512-md8CLNggS1Dx9pUgApzps5uAf+N8GN9xywzmNx9vHAWo94HtBwCCqkSnhIrdfQe83Dhz8Lfo/20Nb1Zxal092w=="],
-
-    "theme-docs/next/postcss": ["postcss@8.4.31", "", { "dependencies": { "nanoid": "^3.3.6", "picocolors": "^1.0.0", "source-map-js": "^1.0.2" } }, "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ=="],
+    "next-16-3-compat/next/@next/swc-win32-x64-msvc": ["@next/swc-win32-x64-msvc@16.3.0", "", { "os": "win32", "cpu": "x64" }, "sha512-fDOggsweNb5SSw0ZKVk6U+gxSyGFFlIBY/LBc1r8GUj4u/6t6oArL+Pmkg0MBnsgR+KkdsURilVH4F3GXUGepA=="],
   }
 }

--- a/package.json
+++ b/package.json
@@ -5,10 +5,13 @@
 	"scripts": {
 		"build": "bun run --cwd packages/themes build",
 		"test": "bun run --cwd packages/themes test",
+		"test:docs": "bun run --cwd apps/docs test",
+		"type-check": "bun run --cwd packages/themes type-check && bun run --cwd apps/docs types:check",
 		"dev:docs": "bun run --cwd apps/docs dev",
 		"build:docs": "bun run --cwd apps/docs build",
 		"lint": "biome check packages apps",
 		"format": "biome format --write packages apps",
+		"verify": "bun run lint && bun run type-check && bun run test && bun run test:docs && bun run --cwd packages/themes size:compare && bun run build:docs",
 		"prepare": "[ \"$CI\" = \"true\" ] || lefthook install"
 	},
 	"devDependencies": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
 		"lint": "biome check packages apps",
 		"format": "biome format --write packages apps",
 		"verify": "bun run lint && bun run type-check && bun run test && bun run test:docs && bun run --cwd packages/themes size:compare && bun run build:docs",
+		"verify:fixture": "bun run --cwd apps/next-16-3 type-check && bun run --cwd apps/next-16-3 build && bun run --cwd apps/next-16-3 test:e2e",
+		"verify:full": "bun run lint && bun run type-check && bun run test && bun run test:docs && bun run --cwd packages/themes type-check:compat && bun run --cwd packages/themes size:compare && bun run build:docs && bun run verify:fixture && bun audit --audit-level=high",
 		"prepare": "[ \"$CI\" = \"true\" ] || lefthook install"
 	},
 	"devDependencies": {

--- a/package.json
+++ b/package.json
@@ -11,9 +11,9 @@
 		"build:docs": "bun run --cwd apps/docs build",
 		"lint": "biome check packages apps",
 		"format": "biome format --write packages apps",
-		"verify": "bun run lint && bun run type-check && bun run test && bun run test:docs && bun run --cwd packages/themes size:compare && bun run build:docs",
+		"verify": "bun run lint && bun run type-check && bun run test && bun run build && bun run test:docs && bun run --cwd packages/themes size:compare && bun run build:docs",
 		"verify:fixture": "bun run --cwd apps/next-16-3 type-check && bun run --cwd apps/next-16-3 build && bun run --cwd apps/next-16-3 test:e2e",
-		"verify:full": "bun run lint && bun run type-check && bun run test && bun run test:docs && bun run --cwd packages/themes type-check:compat && bun run --cwd packages/themes size:compare && bun run build:docs && bun run verify:fixture && bun audit --audit-level=high",
+		"verify:full": "bun run lint && bun run type-check && bun run test && bun run build && bun run test:docs && bun run --cwd packages/themes type-check:compat && bun run --cwd packages/themes size:compare && bun run build:docs && bun run verify:fixture && bun audit --audit-level=high",
 		"prepare": "[ \"$CI\" = \"true\" ] || lefthook install"
 	},
 	"devDependencies": {
@@ -25,12 +25,14 @@
 		"bunup": "^0.16.31",
 		"happy-dom": "^20.11.1",
 		"lefthook": "^2.1.4",
-		"next": ">=16.0.0",
+		"next": ">=16.2.11",
 		"react": "^19.2.4",
 		"react-dom": "^19.2.4",
 		"typescript": "^5.9.3"
 	},
 	"overrides": {
+		"nanoid": "3.3.18",
+		"postcss": "8.5.26",
 		"sharp": "0.35.3"
 	}
 }

--- a/packages/themes/README.md
+++ b/packages/themes/README.md
@@ -20,13 +20,13 @@ Use the Next.js entry in `app/layout.tsx`:
 import { ThemeProvider } from "@wrksz/themes/next";
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
-	return (
-		<html lang="en" suppressHydrationWarning>
-			<body>
-				<ThemeProvider>{children}</ThemeProvider>
-			</body>
-		</html>
-	);
+ return (
+  <html lang="en" suppressHydrationWarning>
+   <body>
+    <ThemeProvider>{children}</ThemeProvider>
+   </body>
+  </html>
+ );
 }
 ```
 
@@ -38,13 +38,13 @@ Use client hooks from the client entry:
 import { useTheme } from "@wrksz/themes/client";
 
 export function ThemeToggle() {
-	const { resolvedTheme, setTheme } = useTheme();
+ const { resolvedTheme, setTheme } = useTheme();
 
-	return (
-		<button onClick={() => setTheme(resolvedTheme === "dark" ? "light" : "dark")}>
-			Toggle theme
-		</button>
-	);
+ return (
+  <button onClick={() => setTheme(resolvedTheme === "dark" ? "light" : "dark")}>
+   Toggle theme
+  </button>
+ );
 }
 ```
 
@@ -55,7 +55,8 @@ export function ThemeToggle() {
 - `localStorage`, `sessionStorage`, `cookie`, `hybrid`, and disabled storage modes.
 - Zero-flash cookie theming via a synchronous pre-paint bootstrap.
 - `initialTheme`, `themeColor`, nested providers, scoped targets, and multi-class theme values.
-- Typed `useTheme`, `useThemeValue`, `useThemeEffect`, `ThemedImage`, and `createThemes`.
+- Typed `useTheme`, `useThemeValue`, `useThemeEffect`, `useHydrated`, `ThemedImage`, and isolated `createThemes` factories.
+- Deterministic `ThemeScript` export for non-Next SSR frameworks.
 - Fine-grained client subpath exports for smaller app bundles.
 - No runtime dependencies.
 
@@ -65,15 +66,15 @@ export function ThemeToggle() {
 import { ThemeProvider } from "@wrksz/themes/next";
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
-	return (
-		<html lang="en" suppressHydrationWarning>
-			<body>
-				<ThemeProvider storage="cookie" defaultTheme="dark" disableTransitionOnChange>
-					{children}
-				</ThemeProvider>
-			</body>
-		</html>
-	);
+ return (
+  <html lang="en" suppressHydrationWarning>
+   <body>
+    <ThemeProvider storage="cookie" defaultTheme="dark" disableTransitionOnChange>
+     {children}
+    </ThemeProvider>
+   </body>
+  </html>
+ );
 }
 ```
 
@@ -86,13 +87,15 @@ wrap request-time themed subtrees in `Suspense` or set `export const instant = f
 ```tsx
 import { ThemeProvider, getTheme } from "@wrksz/themes/next";
 import {
-	ClientThemeProvider,
-	ThemedImage,
-	createThemes,
-	useTheme,
-	useThemeEffect,
-	useThemeValue,
+ ClientThemeProvider,
+ ThemedImage,
+ createThemes,
+ useTheme,
+ useThemeEffect,
+ useHydrated,
+ useThemeValue,
 } from "@wrksz/themes/client";
+import { ThemeScript } from "@wrksz/themes/script";
 ```
 
 Fine-grained client modules are also available:
@@ -101,6 +104,7 @@ Fine-grained client modules are also available:
 import { useTheme } from "@wrksz/themes/client/use-theme";
 import { useThemeValue } from "@wrksz/themes/client/use-theme-value";
 import { useThemeEffect } from "@wrksz/themes/client/use-theme-effect";
+import { useHydrated } from "@wrksz/themes/client/use-hydrated";
 import { ThemedImage } from "@wrksz/themes/client/themed-image";
 import { ClientThemeProvider } from "@wrksz/themes/client/provider";
 import { createThemes } from "@wrksz/themes/client/create-themes";

--- a/packages/themes/scripts/set-version.ts
+++ b/packages/themes/scripts/set-version.ts
@@ -3,15 +3,35 @@ import { resolve } from "node:path";
 
 const PACKAGE_PATH = resolve(import.meta.dir, "../package.json");
 
-const version = process.argv[2];
+export function parseVersionTag(tag: string): string {
+	const match =
+		/^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?$/.exec(
+			tag,
+		);
+	if (!match) throw new Error(`Invalid release tag: ${tag}`);
 
-if (!version) {
-	throw new Error("Version argument is required.");
+	const prerelease = match[4];
+	if (
+		prerelease
+			?.split(".")
+			.some((identifier) => /^\d+$/.test(identifier) && /^0\d+/.test(identifier))
+	) {
+		throw new Error(`Invalid release tag: ${tag}`);
+	}
+	return tag.slice(1);
 }
 
-const content: Record<string, unknown> = JSON.parse(await readFile(PACKAGE_PATH, "utf-8"));
-content.version = version.replace(/^v/, "");
+async function main(): Promise<void> {
+	const tag = process.argv[2];
+	if (!tag) throw new Error("Version argument is required.");
 
-await writeFile(PACKAGE_PATH, `${JSON.stringify(content, null, 2)}\n`);
+	const content: Record<string, unknown> & { version?: unknown } = JSON.parse(
+		await readFile(PACKAGE_PATH, "utf-8"),
+	);
+	content.version = parseVersionTag(tag);
 
-console.log(`Version set to ${content.version}`);
+	await writeFile(PACKAGE_PATH, `${JSON.stringify(content, null, 2)}\n`);
+	console.log(`Version set to ${content.version}`);
+}
+
+if (import.meta.main) await main();

--- a/packages/themes/src/__tests__/set-version.test.ts
+++ b/packages/themes/src/__tests__/set-version.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, test } from "bun:test";
+import { parseVersionTag } from "../../scripts/set-version.js";
+
+describe("parseVersionTag", () => {
+	test("accepts stable and dot-separated prerelease tags", () => {
+		expect(parseVersionTag("v1.2.3")).toBe("1.2.3");
+		expect(parseVersionTag("v1.2.3-rc.1")).toBe("1.2.3-rc.1");
+	});
+
+	test("rejects malformed release tags", () => {
+		for (const tag of ["1.2.3", "v1.2", "v01.2.3", "v1.2.3-", "v1.2.3-rc..1"]) {
+			expect(() => parseVersionTag(tag)).toThrow("Invalid release tag");
+		}
+	});
+});

--- a/packages/themes/src/__tests__/support-metadata.test.ts
+++ b/packages/themes/src/__tests__/support-metadata.test.ts
@@ -9,15 +9,15 @@ describe("support metadata", () => {
 		const packageJson = JSON.parse(
 			readFileSync(resolve(repositoryRoot, "packages/themes/package.json"), "utf-8"),
 		) as { peerDependencies: { react: string; "react-dom": string } };
-		expect(packageJson.peerDependencies.react).toBe("^19.2.0");
-		expect(packageJson.peerDependencies["react-dom"]).toBe("^19.2.0");
+		expect(packageJson.peerDependencies.react).toBe("^18.0.0 || ^19.0.0");
+		expect(packageJson.peerDependencies["react-dom"]).toBe("^18.0.0 || ^19.0.0");
 
 		for (const path of [
 			"README.md",
 			"apps/docs/content/docs/index.mdx",
 			".github/ISSUE_TEMPLATE/framework_support.yml",
 		]) {
-			expect(readFileSync(resolve(repositoryRoot, path), "utf-8")).toContain("React 19.2+");
+			expect(readFileSync(resolve(repositoryRoot, path), "utf-8")).toContain("React 18+");
 		}
 	});
 });

--- a/packages/themes/src/__tests__/support-metadata.test.ts
+++ b/packages/themes/src/__tests__/support-metadata.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const repositoryRoot = resolve(import.meta.dir, "../../../..");
+
+describe("support metadata", () => {
+	test("keeps the React peer minimum aligned with public requirements", () => {
+		const packageJson = JSON.parse(
+			readFileSync(resolve(repositoryRoot, "packages/themes/package.json"), "utf-8"),
+		) as { peerDependencies: { react: string; "react-dom": string } };
+		expect(packageJson.peerDependencies.react).toBe("^19.2.0");
+		expect(packageJson.peerDependencies["react-dom"]).toBe("^19.2.0");
+
+		for (const path of [
+			"README.md",
+			"apps/docs/content/docs/index.mdx",
+			".github/ISSUE_TEMPLATE/framework_support.yml",
+		]) {
+			expect(readFileSync(resolve(repositoryRoot, path), "utf-8")).toContain("React 19.2+");
+		}
+	});
+});


### PR DESCRIPTION
## Stack

PR 9 of 11 in the improvements train; the tooling PRs #41 (Oxc) and #42 (pnpm) stack on top. Depends on `split/08-ts-support-matrix`. This cumulative upstream PR targets `main`; review the commits after `split/08-ts-support-matrix` for this PRs isolated scope.

## Summary

- Split repository quality, library, React compatibility, TypeScript compatibility, docs, and Next.js fixture checks into focused CI jobs.
- Add concurrency cancellation, audit checks, release-tag validation, package-version tests, and support-metadata tests.
- Dogfood `@wrksz/themes` in the documentation app and test its integration.
- Align Dependabot, publishing, issue templates, contributor docs, and agent guidance with the supported stack.
- Document React 18+ support while noting native `useEffectEvent` use on React 19.2+.
- Preserve the final improvements tree except for the intentional React 18 compatibility delta.

## Breaking changes

None in this PR. It documents the breaking changes from PR 6 (implicit Next.js cookie reads) and PR 8 (TypeScript 5.9 minimum) and preserves React 18 compatibility.

## Verification

- Frozen-lockfile install passed.
- Lint, package type-check, tests, docs tests/type-check/build, TypeScript compatibility, and bundle budgets passed.
- Next.js fixture type-check and production build passed.
- Instant Navigation Playwright test passed.
