### PR TITLE
chore(ci): group Dependabot updates into fewer PRs

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -10,6 +10,10 @@ updates:
       commit-message:
           prefix: "chore(deps):"
       labels: ["🔄 dependencies"]
+      groups:
+          npm-workspace:
+              patterns:
+                  - "*"
 
     - package-ecosystem: "github-actions"
       directory: "/"
@@ -21,3 +25,7 @@ updates:
       commit-message:
           prefix: "chore(deps->actions):"
       labels: ["🔄 dependencies"]
+      groups:
+          github-actions:
+              patterns:
+                  - "*"


### PR DESCRIPTION
## Summary
- Rebase onto current `main` after the pnpm workspace switch
- Add Dependabot `groups` with `patterns: ["*"]` for the root npm workspace and GitHub Actions ecosystem
- Weekly version updates open one PR per ecosystem instead of one PR per dependency

## Test plan
- [ ] Confirm Dependabot config validates in the GitHub Dependabot UI / next scheduled run
- [ ] After the next weekly run, verify grouped PRs appear for npm and actions