### PR TITLE
perf(docs): defer Analytics and code-split below-fold home islands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ yarn-error.log*
 packages/themes/benchmarks/.bundle-size/
 
 .pnpm-store/
+.worktrees/

--- a/apps/docs/src/app/(home)/page.tsx
+++ b/apps/docs/src/app/(home)/page.tsx
@@ -1,28 +1,32 @@
+import dynamic from "next/dynamic";
 import { MotionProvider } from "@/components/motion-provider";
-import { Comparison } from "./comparison";
-import { FeaturesGrid } from "./features";
 import { Footer } from "./footer";
 import { Hero } from "./hero";
-import { Roadmap } from "./roadmap";
+
+const FeaturesGrid = dynamic(() => import("./features").then((mod) => mod.FeaturesGrid));
+const Comparison = dynamic(() => import("./comparison").then((mod) => mod.Comparison));
+const Roadmap = dynamic(() => import("./roadmap").then((mod) => mod.Roadmap));
 
 export default function HomePage() {
 	return (
-		<MotionProvider>
-			<main className="relative flex flex-col items-center px-4 overflow-hidden">
-				<div
-					aria-hidden
-					className="pointer-events-none absolute top-0 left-1/2 -translate-x-1/2 h-[600px] w-full max-w-3xl blur-[100px]"
-					style={{
-						background:
-							"radial-gradient(ellipse at 50% -10%, oklch(0.541 0.247 293.009 / 0.15), transparent 65%)",
-					}}
-				/>
+		<main className="relative flex flex-col items-center px-4 overflow-hidden">
+			<div
+				aria-hidden
+				className="pointer-events-none absolute top-0 left-1/2 -translate-x-1/2 h-[600px] w-full max-w-3xl blur-[100px]"
+				style={{
+					background:
+						"radial-gradient(ellipse at 50% -10%, oklch(0.541 0.247 293.009 / 0.15), transparent 65%)",
+				}}
+			/>
+			<MotionProvider>
 				<Hero />
+			</MotionProvider>
+			<MotionProvider>
 				<FeaturesGrid />
 				<Comparison />
 				<Roadmap />
-				<Footer />
-			</main>
-		</MotionProvider>
+			</MotionProvider>
+			<Footer />
+		</main>
 	);
 }

--- a/apps/docs/src/app/layout.tsx
+++ b/apps/docs/src/app/layout.tsx
@@ -2,8 +2,8 @@ import { ThemeProvider } from "@wrksz/themes/next";
 import { RootProvider } from "fumadocs-ui/provider/next";
 import type { Metadata } from "next";
 import "./global.css";
-import { Analytics } from "@vercel/analytics/next";
 import { Inter } from "next/font/google";
+import { Analytics } from "@/components/deferred-analytics";
 import { appThemes, themeProviderDefaults } from "@/lib/theme-config";
 
 const inter = Inter({

--- a/apps/docs/src/components/deferred-analytics.tsx
+++ b/apps/docs/src/components/deferred-analytics.tsx
@@ -1,0 +1,8 @@
+"use client";
+
+import dynamic from "next/dynamic";
+
+export const Analytics = dynamic(
+	() => import("@vercel/analytics/next").then((mod) => mod.Analytics),
+	{ ssr: false },
+);


### PR DESCRIPTION
## Summary
- Load `@vercel/analytics/next` after hydration via `next/dynamic` (`ssr: false`) so Analytics is not on the docs critical path.
- Code-split the homepage features, comparison, and roadmap islands with `next/dynamic` (SSR kept). Hero stays eager for LCP; `LazyMotion` wraps Hero and those islands separately instead of the whole home tree, including Footer.
- Ignore `.worktrees/` at the repo root so local git worktrees stay out of the index.

## Test plan
- [x] `pnpm --filter theme-docs build` succeeds
- [x] Production homepage SSR includes Hero, features, comparison, and roadmap copy
- [x] Browser smoke (`next start`): homepage sections render; pnpm install tab updates the command; `/docs` still loads
- [x] After hydration, `window.va` is a function and `/_vercel/insights/script.js` is injected (local production cannot confirm a recorded Vercel page view)
- [ ] Confirm a real page view in Vercel Analytics after this is deployed to `themes.wrksz.dev`
- Library `size:compare` is unaffected (docs-only change)


Made with [Cursor](https://cursor.com)