### PR TITLE
docs: document Shadow DOM themeRoot and align 2.0 public API copy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,6 +20,6 @@ Use `pnpm verify:full` before requesting release review. It adds TypeScript 5.9/
 - Review bundle baselines after correctness work; never raise a threshold solely to pass CI.
 - Use conventional commit messages.
 
-The supported minimums are React and React DOM 19.2, Next.js 16, and TypeScript 5.9. The `apps/next-16-3` preview fixture protects behavior against upcoming Next.js routing changes.
+The supported minimums are React 18+, React DOM 18+, Next.js 16, and TypeScript 5.9. React 19.2+ uses the native `useEffectEvent`; React 18 and earlier React 19 releases use the compatibility fallback. The `apps/next-16-3` preview fixture protects behavior against upcoming Next.js routing changes.
 
 API documentation belongs in `apps/docs/content/docs`; avoid parallel prop tables in README files. Releases are tag-driven from `vMAJOR.MINOR.PATCH` tags, optionally with dot-separated prerelease identifiers, and are published only by the provenance-enabled workflow.

--- a/README.md
+++ b/README.md
@@ -167,26 +167,11 @@ with npm provenance from GitHub Actions.
 
 ### `ThemeProvider`
 
-| Prop                        | Type                                                                   | Default             | Description                                                                                                                                                                      |
-| --------------------------- | ---------------------------------------------------------------------- | ------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `themes`                    | `string[]`                                                             | `["light", "dark"]` | Available themes                                                                                                                                                                 |
-| `defaultTheme`              | `string`                                                               | `"system"`          | Theme used when no preference is stored                                                                                                                                          |
-| `forcedTheme`               | `string`                                                               | -                   | Force a specific theme, ignoring user preference                                                                                                                                 |
-| `initialTheme`              | `string`                                                               | -                   | Server-provided theme that overrides storage on mount. User can still call `setTheme` to change it                                                                               |
-| `enableSystem`              | `boolean`                                                              | `true`              | Detect system preference via `prefers-color-scheme`                                                                                                                              |
-| `enableColorScheme`         | `boolean`                                                              | `true`              | Set native `color-scheme` CSS property                                                                                                                                           |
-| `attribute`                 | `string \| string[]`                                                   | `"class"`           | HTML attribute(s) to set on target element (`"class"`, `"data-theme"`, etc.)                                                                                                     |
-| `value`                     | `Record<string, string>`                                               | -                   | Map theme names to attribute values                                                                                                                                              |
-| `target`                    | `string`                                                               | `"html"`            | Element to apply theme to (`"html"`, `"body"`, or a CSS selector)                                                                                                                |
-| `storageKey`                | `string`                                                               | `"theme"`           | Key used for storage                                                                                                                                                             |
-| `storage`                   | `"localStorage" \| "sessionStorage" \| "cookie" \| "hybrid" \| "none"` | `"localStorage"`    | Where to persist the theme. The bootstrap reads cookies before paint; `"hybrid"` prefers the cookie and mirrors writes to `localStorage` for cross-tab sync                      |
-| `disableTransitionOnChange` | `boolean \| string`                                                    | `false`             | Suppress CSS transitions when switching themes. `true` disables all. Pass a CSS `transition` value (e.g. `"background-color 0s, color 0s"`) to suppress only specific properties |
-| `followSystem`              | `boolean`                                                              | `false`             | Always follow system preference, ignores stored value on mount                                                                                                                   |
-| `themeColor`                | `string \| Record<string, string>`                                     | -                   | Update `<meta name="theme-color">` on theme change                                                                                                                               |
-| `nonce`                     | `string`                                                               | -                   | CSP nonce for the inline script                                                                                                                                                  |
-| `onThemeChange`             | `(theme: string) => void`                                              | -                   | Called when theme changes. Receives the selected value (may be `"system"`). When system preference changes while theme is `"system"`, fires with the resolved value              |
-| `onStorageError`            | `(error: unknown) => void`                                             | -                   | Reports storage failures without interrupting in-memory theme updates                                                                                                            |
-| `scriptProps`               | `ScriptHTMLAttributes<HTMLScriptElement>`                              | -                   | Extra bootstrap script attributes                                                                                                                                                |
+The canonical prop table lives on the docs site: [ThemeProvider](https://themes.wrksz.dev/docs/api/theme-provider).
+
+```tsx
+import { ThemeProvider } from "@wrksz/themes/next";
+```
 
 ### Opt-in extended provider
 
@@ -222,7 +207,7 @@ import { ClientThemeProvider } from "@wrksz/themes/client/extended-provider";
 - `enableSameDocumentSync?: boolean` synchronizes providers with the same storage key.
 - `systemThemeMap?: { light: Theme; dark: Theme } | Record<Theme, { light: Theme; dark: Theme }>`
   maps system preferences to custom names or preserves variant families.
-- `themeRoot?: Element | ShadowRoot` targets a client-owned element or a ShadowRoot host.
+- `themeRoot?: Element | ShadowRoot` targets a client-owned element or a ShadowRoot host. Worked example: [Shadow DOM](https://themes.wrksz.dev/docs/examples/shadow-dom).
 
 ### `useTheme`
 

--- a/apps/docs/content/docs/api/client-theme-provider.mdx
+++ b/apps/docs/content/docs/api/client-theme-provider.mdx
@@ -5,6 +5,8 @@ description: Theme provider for use inside Client Components.
 
 `ClientThemeProvider` is the client-side counterpart of [`ThemeProvider`](/docs/api/theme-provider). Use it when you need a nested provider inside a Client Component - `ThemeProvider` renders an inline `<script>` which is not allowed in Client Components.
 
+Two client entries exist. The default stays small. Shadow DOM, custom system maps, and same-document sync live on the opt-in extended import.
+
 ```tsx
 "use client";
 
@@ -21,18 +23,21 @@ export function AdminShell({ children }: { children: React.ReactNode }) {
 
 ## ThemeProvider vs ClientThemeProvider
 
-| | `ThemeProvider` | `ClientThemeProvider` |
-|---|---|---|
-| Renders inline script | Yes - prevents flash on load | No |
-| Use in Server Components | Yes | No |
-| Use in Client Components | No | Yes |
-| Supports all props | Yes | Yes |
+| | `ThemeProvider` (`@wrksz/themes/next`) | `ClientThemeProvider` (`@wrksz/themes/client`) | Extended (`@wrksz/themes/client/extended-provider`) |
+|---|---|---|---|
+| Renders inline script | Yes - prevents flash on load | No | No |
+| Use in Server Components | Yes | No | No |
+| Use in Client Components | No | Yes | Yes |
+| Default props | Yes | Yes (`nonce` unused) | Yes, plus `themeRoot`, `systemThemeMap`, `enableSameDocumentSync` |
+| `themeRoot` | No | No | Yes. Omitted from `@wrksz/themes/next/extended` |
 
 For your root layout, always use `ThemeProvider`. Use `ClientThemeProvider` only for nested providers deeper in the tree.
 
 ## Props
 
-Accepts the same props as [`ThemeProvider`](/docs/api/theme-provider#props), with one exception: the `nonce` prop is not used since `ClientThemeProvider` renders no inline script.
+The default `@wrksz/themes/client` entry accepts the same props as [`ThemeProvider`](/docs/api/theme-provider#props), with one exception: the `nonce` prop is not used since `ClientThemeProvider` renders no inline script.
+
+It does **not** accept `themeRoot`, `systemThemeMap`, or `enableSameDocumentSync`. Those belong on [`@wrksz/themes/client/extended-provider`](/docs/api/theme-provider#extended-provider). See [Shadow DOM](/docs/examples/shadow-dom) for `themeRoot`.
 
 ## Examples
 
@@ -65,12 +70,14 @@ export default function DashboardLayout({ children }) {
 #dashboard-root { --bg: #ffffff; --fg: #0a0a0a; }
 ```
 
+For a client-owned `Element` or `ShadowRoot` (no selector, no bootstrap), use `themeRoot` on the [extended client provider](/docs/examples/shadow-dom).
+
 ### Nested provider in a Client Component
 
 ```tsx
 "use client";
 
-import { ClientThemeProvider, useTheme } from "@wrksz/themes/client";
+import { ClientThemeProvider } from "@wrksz/themes/client";
 
 export function Sidebar({ children }: { children: React.ReactNode }) {
   return (
@@ -82,3 +89,17 @@ export function Sidebar({ children }: { children: React.ReactNode }) {
 ```
 
 Each `ClientThemeProvider` maintains its own independent theme state - nested providers do not affect each other.
+
+### Shadow DOM
+
+Import the extended client provider and pass the `ShadowRoot` from `attachShadow`. There is no anti-flash script: the bootstrap cannot see a client-owned shadow tree.
+
+```tsx
+import { ClientThemeProvider } from "@wrksz/themes/client/extended-provider";
+
+<ClientThemeProvider themeRoot={shadowRoot} storage="none" defaultTheme="dark">
+  {children}
+</ClientThemeProvider>
+```
+
+Full walkthrough, `:host(.dark)` CSS, and why `target` is ignored when `themeRoot` is set: [Shadow DOM](/docs/examples/shadow-dom).

--- a/apps/docs/content/docs/api/create-themes.mdx
+++ b/apps/docs/content/docs/api/create-themes.mdx
@@ -27,7 +27,8 @@ export const { ThemeProvider, useTheme, useThemeValue, useThemeEffect, ThemedIma
 - `useThemeValue` maps are checked against your union (plus optional `default`).
 - `ThemedImage` requires a source for every configured theme.
 - Provider defaults can still be overridden per usage, while the theme tuple stays fixed.
-- The returned `ThemeProvider` is a client provider. Use `@wrksz/themes/next` for the root Next.js provider that injects the anti-flash script.
+- The returned `ThemeProvider` is the **default client** provider. Use `@wrksz/themes/next` for the root Next.js provider that injects the anti-flash script.
+- `themeRoot`, `systemThemeMap`, and `enableSameDocumentSync` are not on the factory. Compose with [`@wrksz/themes/client/extended-provider`](/docs/api/client-theme-provider) when a subtree needs those props.
 
 ```tsx title="app/theme-toggle.tsx"
 "use client";

--- a/apps/docs/content/docs/api/get-theme.mdx
+++ b/apps/docs/content/docs/api/get-theme.mdx
@@ -22,8 +22,10 @@ Two variants depending on context:
 import { NextResponse } from "next/server";
 import { getTheme } from "@wrksz/themes/next";
 
+const themes = ["light", "dark"] as const;
+
 export function proxy(request: Request) {
-  const theme = getTheme(request, { defaultTheme: "dark" });
+  const theme = getTheme(request, { themes, defaultTheme: "dark" });
   const response = NextResponse.next();
   response.headers.set("x-theme", theme);
   return response;
@@ -58,12 +60,12 @@ const theme = await getTheme({
 // theme: "light" | "dark" | "system"
 ```
 
-When `themes` is omitted, `getTheme` returns `string` because an existing cookie can contain any stored value.
+When `themes` is omitted, `getTheme` returns `string` because an existing cookie can contain any stored value. Always pass `themes` when you will put the result on markup or seed a provider.
 
 ## Layout - apply class directly on `<html>`
 
 <Callout type="warn">
-  <Breaking /> Required more often in **`2.0.0-beta.1`** because the provider no longer injects the cookie class for you.
+  <Breaking /> Required more often in **`2.0.0-beta.1`** because the provider no longer injects the cookie class for you. Do not put unresolved `"system"` on `<html className>`. Pass `themes`, and pass `initialTheme` when seeding the provider.
 </Callout>
 
 Use this pattern when server-rendered markup itself must depend on the theme:
@@ -73,13 +75,20 @@ import { ThemeProvider, getTheme } from "@wrksz/themes/next";
 
 export const instant = false;
 
+const themes = ["light", "dark"] as const;
+
 export default async function RootLayout({ children }: { children: React.ReactNode }) {
-  const theme = await getTheme({ defaultTheme: "dark" });
+  const theme = await getTheme({ themes, defaultTheme: "dark" });
 
   return (
     <html lang="en" className={theme} suppressHydrationWarning>
       <body>
-        <ThemeProvider storage="cookie" defaultTheme="dark">
+        <ThemeProvider
+          themes={themes}
+          storage="cookie"
+          defaultTheme="dark"
+          initialTheme={theme}
+        >
           {children}
         </ThemeProvider>
       </body>

--- a/apps/docs/content/docs/api/theme-provider.mdx
+++ b/apps/docs/content/docs/api/theme-provider.mdx
@@ -75,7 +75,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
 | `target` | `string` | `"html"` | Element to apply theme to (`"html"`, `"body"`, or a CSS selector) |
 | `storageKey` | `string` | `"theme"` | Key used for storage |
 | `storage` | `"localStorage" \| "sessionStorage" \| "cookie" \| "hybrid" \| "none"` | `"localStorage"` | Where to persist the theme. The bootstrap reads cookies synchronously before paint. `"hybrid"` prefers the cookie and mirrors writes to `localStorage` for cross-tab sync. <Breaking /> Next provider no longer reads the cookie via `cookies()` on the server. |
-| `cookieOptions` | `CookieOptions` | - | Cookie attributes applied when writing the theme cookie. Only used when `storage="cookie"`. See [CookieOptions](#cookieoptions). |
+| `cookieOptions` | `CookieOptions` | - | Cookie attributes applied when writing the theme cookie. Used when `storage` is `"cookie"` or `"hybrid"`. See [CookieOptions](#cookieoptions). |
 | `disableTransitionOnChange` | `boolean \| string` | `false` | Suppress CSS transitions on initial load and when switching themes. `true` disables all transitions. Pass a CSS `transition` value (e.g. `"background-color 0s, color 0s"`) to suppress only specific properties while keeping others (transforms, opacity, etc.) intact. |
 | `followSystem` | `boolean` | `false` | Always follow system preference, ignores stored value on mount |
 | `themeColor` | `string \| Record<string, string>` | - | Update `<meta name="theme-color">` on theme change |
@@ -92,7 +92,7 @@ Heavier capabilities stay behind opt-in imports so the default provider bundle d
 |------|------|---------|-------------|
 | `enableSameDocumentSync` | `boolean` | `false` | Synchronize providers that share a storage key in the same document |
 | `systemThemeMap` | `{ light: string; dark: string } \| Record<string, { light: string; dark: string }>` | - | Serializable custom resolution for system-aware variants |
-| `themeRoot` | `Element \| ShadowRoot` | - | Client-only Shadow DOM/custom root. Use `@wrksz/themes/client/extended-provider`. Use `target` when the root must be themed before hydration |
+| `themeRoot` | `Element \| ShadowRoot` | - | Client-only Shadow DOM or custom root. **Not on** `@wrksz/themes/next/extended` — a DOM object cannot go through the inline bootstrap. Import [`@wrksz/themes/client/extended-provider`](/docs/api/client-theme-provider). Worked example: [Shadow DOM](/docs/examples/shadow-dom). Use `target` when the root must be themed before hydration. |
 
 ## Security notes
 
@@ -360,7 +360,7 @@ Works with CSS variables too:
 
 ## CookieOptions
 
-Options applied when writing the theme cookie. Only relevant when `storage="cookie"`.
+Options applied when writing the theme cookie. Used when `storage` is `"cookie"` or `"hybrid"`.
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|

--- a/apps/docs/content/docs/examples/framework-agnostic.mdx
+++ b/apps/docs/content/docs/examples/framework-agnostic.mdx
@@ -23,7 +23,7 @@ export function Document({ children }: { children: React.ReactNode }) {
 }
 ```
 
-`ThemeScript` and `getScript` use a build-generated deterministic bootstrap so bundlers cannot rewrite behavior through `Function#toString()`. Keep script configuration equal to the provider configuration.
+`ThemeScript` and `getScript` use a build-generated deterministic bootstrap so bundlers cannot rewrite behavior through `Function#toString()`. Keep script configuration equal to the provider configuration. `ThemeScript` / `getScript` cannot take `themeRoot` — Shadow widgets stay on `@wrksz/themes/client/extended-provider` after mount. See [Shadow DOM](/docs/examples/shadow-dom).
 
 ```tsx
 import { getScript, ThemeScript } from "@wrksz/themes/script";

--- a/apps/docs/content/docs/examples/hybrid-storage.mdx
+++ b/apps/docs/content/docs/examples/hybrid-storage.mdx
@@ -3,7 +3,7 @@ title: Hybrid storage
 description: Use cookies for SSR and localStorage for cross-tab sync.
 ---
 
-`storage="hybrid"` stores the theme in a cookie and mirrors it to `localStorage`. The cookie lets `@wrksz/themes/next` read the theme on the server, while `localStorage` keeps other tabs in sync.
+`storage="hybrid"` stores the theme in a cookie and mirrors it to `localStorage`. The pre-paint bootstrap reads the cookie before the first paint. The Next `ThemeProvider` does not call `cookies()`. `localStorage` keeps other tabs in sync.
 
 ## Root layout
 

--- a/apps/docs/content/docs/examples/meta-theme-color.mdx
+++ b/apps/docs/content/docs/examples/meta-theme-color.mdx
@@ -5,6 +5,10 @@ description: Update the browser theme color on theme change for Safari and PWAs.
 
 The `themeColor` prop keeps `<meta name="theme-color">` in sync with the current theme. Browsers like Safari use this to color the tab bar and status bar.
 
+<Callout type="info">
+  `themeColor` always writes to `document.head`, including when [`themeRoot`](/docs/examples/shadow-dom) is a shadow root. That is document chrome, not per-widget browser chrome.
+</Callout>
+
 ## Per-theme colors
 
 ```tsx

--- a/apps/docs/content/docs/examples/meta.json
+++ b/apps/docs/content/docs/examples/meta.json
@@ -9,6 +9,7 @@
     "system-variants",
     "data-attribute",
     "scoped-theming",
+    "shadow-dom",
     "forced-theme",
     "hybrid-storage",
     "server-theme",

--- a/apps/docs/content/docs/examples/scoped-theming.mdx
+++ b/apps/docs/content/docs/examples/scoped-theming.mdx
@@ -67,3 +67,5 @@ The `target` prop accepts any CSS selector, plus the shortcuts `"html"` (default
 <ClientThemeProvider target="#my-element">   // applies to #my-element
 <ClientThemeProvider target=".my-class">     // applies to .my-class (first match)
 ```
+
+`target` is a CSS selector in the light DOM. The Next bootstrap can apply it before paint. For a client-owned `Element` or `ShadowRoot` with no selector and no bootstrap, use `themeRoot` on `@wrksz/themes/client/extended-provider` instead. See [Shadow DOM](/docs/examples/shadow-dom).

--- a/apps/docs/content/docs/examples/shadow-dom.mdx
+++ b/apps/docs/content/docs/examples/shadow-dom.mdx
@@ -1,0 +1,83 @@
+---
+title: Shadow DOM
+description: Theme a ShadowRoot host from the opt-in extended client provider.
+---
+
+`themeRoot` lives on the **opt-in** client entry `@wrksz/themes/client/extended-provider`. It is omitted from `@wrksz/themes/next/extended` because a DOM object cannot go through the inline bootstrap.
+
+Pass a `ShadowRoot` or an `Element`. A `ShadowRoot` applies class / data attributes / `color-scheme` to **`shadowRoot.host`**. Transition-disable `<style>` is appended **inside the shadow root**, then removed after two frames.
+
+<Callout type="warn">
+  There is no anti-flash script for a client-owned shadow tree. The bootstrap cannot see it, so the host may paint unthemed until the provider mounts. Prefer `storage="none"` for isolated widgets.
+</Callout>
+
+When `themeRoot` is set, `target` is ignored. Use [`target`](/docs/examples/scoped-theming) on the default provider when a light-DOM node must be themed before paint.
+
+## Portal into a shadow root
+
+Keep the host in the light DOM, attach a shadow tree, and portal the provider so it is an ancestor of the themed UI:
+
+```tsx title="components/shadow-widget.tsx"
+"use client";
+
+import { useLayoutEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import { ClientThemeProvider } from "@wrksz/themes/client/extended-provider";
+
+export function ShadowWidget({ children }: { children: React.ReactNode }) {
+  const hostRef = useRef<HTMLDivElement>(null);
+  const [shadowRoot, setShadowRoot] = useState<ShadowRoot | null>(null);
+
+  useLayoutEffect(() => {
+    if (!hostRef.current || hostRef.current.shadowRoot) return;
+    setShadowRoot(hostRef.current.attachShadow({ mode: "open" }));
+  }, []);
+
+  return (
+    <div ref={hostRef}>
+      {shadowRoot
+        ? createPortal(
+            <ClientThemeProvider themeRoot={shadowRoot} storage="none" defaultTheme="dark">
+              {children}
+            </ClientThemeProvider>,
+            shadowRoot,
+          )
+        : null}
+    </div>
+  );
+}
+```
+
+Open vs closed: pass the `ShadowRoot` you got from `attachShadow`. Closed mode still works if you keep that reference.
+
+## Shadow CSS
+
+Class and data attributes land on the **host**, not on `:root`. Style with `:host(...)`. Children typically live in the shadow tree via `createPortal`:
+
+```css
+:host(.dark) {
+  --bg: #0a0a0a;
+  --fg: #fafafa;
+}
+
+:host([data-theme="dark"]) {
+  --bg: #0a0a0a;
+  --fg: #fafafa;
+}
+```
+
+## Light-DOM `themeRoot`
+
+`themeRoot` also accepts a client-owned element when you already have a node and do not want a selector:
+
+```tsx
+<ClientThemeProvider themeRoot={someElement} storage="none" defaultTheme="dark">
+  {children}
+</ClientThemeProvider>
+```
+
+For a CSS selector that the Next bootstrap can see before hydration, use `target="#id"` on the default provider instead. See [Scoped theming](/docs/examples/scoped-theming).
+
+<Callout type="info">
+  `themeColor` still writes `<meta name="theme-color">` on `document.head`. That is document chrome, not per-widget browser chrome, even when `themeRoot` is a shadow root. See [Meta theme-color](/docs/examples/meta-theme-color).
+</Callout>

--- a/apps/docs/content/docs/examples/system-variants.mdx
+++ b/apps/docs/content/docs/examples/system-variants.mdx
@@ -20,7 +20,57 @@ Keep `"light"` and `"dark"` as theme selections so `enableSystem` can resolve `"
 </ThemeProvider>
 ```
 
-The default Next provider stays on this light path on purpose. Custom system maps that rename the selection itself (for example resolving system directly to `"paper"` / `"midnight"`) are heavier and belong behind an opt-in extended API so the core bundle stays small.
+The default Next provider stays on this light path on purpose. Custom system maps that rename the selection itself belong behind `@wrksz/themes/next/extended` so the core bundle stays small. See [ThemeProvider Extended](/docs/api/theme-provider#extended-provider).
+
+## Custom system names
+
+When the stored selection should be `"paper"` / `"midnight"` rather than `"light"` / `"dark"`, pass a direct `{ light, dark }` map:
+
+```tsx title="app/layout.tsx"
+import { ThemeProvider } from "@wrksz/themes/next/extended";
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en" suppressHydrationWarning>
+      <body>
+        <ThemeProvider
+          themes={["paper", "midnight"]}
+          defaultTheme="system"
+          systemThemeMap={{ light: "paper", dark: "midnight" }}
+        >
+          {children}
+        </ThemeProvider>
+      </body>
+    </html>
+  );
+}
+```
+
+`system` then resolves to `"paper"` or `"midnight"` from `prefers-color-scheme`.
+
+## Variant families
+
+A `Record` map keeps a variant family (for example red vs blue) while still following system light/dark. Pair it with `followSystem`:
+
+```tsx
+import { ThemeProvider } from "@wrksz/themes/next/extended";
+
+<ThemeProvider
+  themes={["light-red", "dark-red", "light-blue", "dark-blue"]}
+  defaultTheme="light-red"
+  followSystem
+  systemThemeMap={{
+    "light-red": { light: "light-red", dark: "dark-red" },
+    "dark-red": { light: "light-red", dark: "dark-red" },
+    "light-blue": { light: "light-blue", dark: "dark-blue" },
+    "dark-blue": { light: "light-blue", dark: "dark-blue" },
+  }}
+>
+  {children}
+</ThemeProvider>
+```
+
+Selecting `"light-red"` stays in the red family; OS dark mode resolves to `"dark-red"`. `systemThemeMap` is serializable, so it works on the Next extended bootstrap. For a client-owned `themeRoot`, use [`@wrksz/themes/client/extended-provider`](/docs/examples/shadow-dom) instead.
 
 ## Contrast as an independent axis
 

--- a/apps/docs/content/docs/index.mdx
+++ b/apps/docs/content/docs/index.mdx
@@ -86,6 +86,8 @@ export function ThemeToggle() {
 | `@wrksz/themes/client/themed-image` | Direct `ThemedImage` import |
 | `@wrksz/themes/client/provider` | Direct `ClientThemeProvider` import |
 | `@wrksz/themes/client/create-themes` | Direct `createThemes` import |
+| `@wrksz/themes/next/extended` | Opt-in Next.js `ThemeProvider` with `systemThemeMap` and same-document sync |
+| `@wrksz/themes/client/extended-provider` | Opt-in `ClientThemeProvider` with `themeRoot`, `systemThemeMap`, and same-document sync |
 | `@wrksz/themes` | Client-safe `ThemeProvider` alias and `createThemes` for framework-neutral React usage |
 
 <Callout type="info">
@@ -102,4 +104,4 @@ export function ThemeToggle() {
 
 - [ThemeProvider API](/docs/api/theme-provider) - all available props
 - [useTheme API](/docs/api/use-theme) - hook reference
-- [Examples](/docs/examples) - Tailwind, data attributes, scoped theming, and more
+- [Examples](/docs/examples) - Tailwind, scoped theming, [Shadow DOM](/docs/examples/shadow-dom), and more

--- a/apps/docs/content/docs/why-not-next-themes.mdx
+++ b/apps/docs/content/docs/why-not-next-themes.mdx
@@ -3,7 +3,7 @@ title: Why not next-themes?
 description: A comparison of @wrksz/themes and next-themes.
 ---
 
-`@wrksz/themes` is a near drop-in replacement for `next-themes`. It fixes every known bug and adds missing features. The API is identical - migrating requires changing one import line.
+`@wrksz/themes` is a near drop-in replacement for `next-themes`. It fixes every known bug and adds missing features. The API is identical - migrating requires changing one import line. Shadow DOM (`themeRoot`) and custom system maps (`systemThemeMap`) are opt-in extended entries, not default bundle weight.
 
 <Callout type="warn">
   `next-themes` is slowly maintained - 43 open issues and 16 open PRs as of March 2026, with React 19 compatibility bugs still unresolved in the latest release.

--- a/packages/themes/src/__tests__/support-metadata.test.ts
+++ b/packages/themes/src/__tests__/support-metadata.test.ts
@@ -1,8 +1,17 @@
 import { describe, expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
+import type {
+	ExtendedNextThemeProviderProps,
+	ExtendedThemeProviderProps,
+} from "../core/extended-types.js";
+import type { ThemeProviderProps } from "../core/types.js";
 
 const repositoryRoot = resolve(import.meta.dir, "../../../..");
+
+type HasKey<T, K extends PropertyKey> = K extends keyof T ? true : false;
+
+function expectType<T>(_value: T): void {}
 
 describe("support metadata", () => {
 	test("keeps the React peer minimum aligned with public requirements", () => {
@@ -16,8 +25,43 @@ describe("support metadata", () => {
 			"README.md",
 			"apps/docs/content/docs/index.mdx",
 			".github/ISSUE_TEMPLATE/framework_support.yml",
+			"CONTRIBUTING.md",
 		]) {
 			expect(readFileSync(resolve(repositoryRoot, path), "utf-8")).toContain("React 18+");
 		}
+
+		expect(readFileSync(resolve(repositoryRoot, "AGENTS.md"), "utf-8")).toContain(
+			"React/React DOM 18",
+		);
+	});
+
+	test("keeps extended props off the default ThemeProvider contract", () => {
+		const typesSource = readFileSync(
+			resolve(repositoryRoot, "packages/themes/src/core/types.ts"),
+			"utf-8",
+		);
+		const extendedTypesSource = readFileSync(
+			resolve(repositoryRoot, "packages/themes/src/core/extended-types.ts"),
+			"utf-8",
+		);
+		const defaultProps = typesSource.slice(
+			typesSource.indexOf("export type ThemeProviderProps"),
+			typesSource.indexOf("export type ThemeContextValue"),
+		);
+
+		expect(defaultProps).not.toContain("systemThemeMap");
+		expect(defaultProps).not.toContain("themeRoot");
+		expect(extendedTypesSource).toContain("systemThemeMap?:");
+		expect(extendedTypesSource).toContain("themeRoot?:");
+		expect(extendedTypesSource).toMatch(
+			/Omit<\s*ExtendedThemeProviderProps<Themes>,\s*"themeRoot"\s*>/,
+		);
+
+		expectType<HasKey<ThemeProviderProps, "systemThemeMap">>(false);
+		expectType<HasKey<ThemeProviderProps, "themeRoot">>(false);
+		expectType<HasKey<ExtendedThemeProviderProps, "systemThemeMap">>(true);
+		expectType<HasKey<ExtendedThemeProviderProps, "themeRoot">>(true);
+		expectType<HasKey<ExtendedNextThemeProviderProps, "systemThemeMap">>(true);
+		expectType<HasKey<ExtendedNextThemeProviderProps, "themeRoot">>(false);
 	});
 });

--- a/packages/themes/src/core/types.ts
+++ b/packages/themes/src/core/types.ts
@@ -79,7 +79,7 @@ export type ThemeProviderProps<Themes extends string = DefaultTheme> = {
 	followSystem?: boolean;
 	/** Server-provided theme that overrides storage on mount (e.g. from a database). User can still call setTheme to change it. */
 	initialTheme?: ThemeSelection<Themes>;
-	/** Cookie options, only used when storage="cookie" */
+	/** Cookie options, used when storage is "cookie" or "hybrid" */
 	cookieOptions?: CookieOptions;
 };
 


### PR DESCRIPTION
## Summary
- Extended `themeRoot` / `systemThemeMap` already shipped; docs now treat them as opt-in entries instead of default ThemeProvider props, with a worked Shadow DOM example.
- 2.0 copy matches the code: `cookieOptions` applies to cookie and hybrid, the Next provider does not call `cookies()`, and `getTheme` recipes always pass `themes` + `initialTheme` without putting unresolved `"system"` on `<html>`.
- CONTRIBUTING now states the React 18+ floor (19.2 for native `useEffectEvent`), and support-metadata tests guard that split.

## Test plan
- [ ] `pnpm --filter @wrksz/themes test src/__tests__/support-metadata.test.ts`
- [ ] `pnpm --filter theme-docs test` after a library build
- [ ] Confirm `/docs/examples/shadow-dom` is in the examples sidebar next to scoped theming
- [ ] Grep: `themeRoot` must not appear as a default ThemeProvider prop


Made with [Cursor](https://cursor.com)