### PR TITLE
chore(ci): finish pnpm leftover drift and stop triple-building

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,10 @@ on:
       - "pnpm-workspace.yaml"
       - "oxlint.config.ts"
       - "oxfmt.config.ts"
+      - "README.md"
+      - "CONTRIBUTING.md"
+      - "AGENTS.md"
+      - "lefthook.yml"
       - ".github/workflows/ci.yml"
   pull_request:
     branches: [main]
@@ -24,6 +28,10 @@ on:
       - "pnpm-workspace.yaml"
       - "oxlint.config.ts"
       - "oxfmt.config.ts"
+      - "README.md"
+      - "CONTRIBUTING.md"
+      - "AGENTS.md"
+      - "lefthook.yml"
       - ".github/workflows/ci.yml"
 
 concurrency:
@@ -44,10 +52,6 @@ jobs:
         with:
           node-version: 24
           cache: pnpm
-
-      - uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: 1.3.9
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -92,10 +96,8 @@ jobs:
         run: pnpm --filter @wrksz/themes build
 
       - name: Bundle size
-        run: pnpm --filter @wrksz/themes size
-
-      - name: Bundle size baseline
-        run: pnpm --filter @wrksz/themes size:compare
+        working-directory: packages/themes
+        run: bun scripts/bundle-size.ts --compare benchmarks/baseline.json
 
   react-compatibility:
     name: React ${{ matrix.react }}
@@ -252,8 +254,24 @@ jobs:
       - name: Build fixture
         run: pnpm --filter next-16-3-compat build
 
+      # Local verify:full needs the same browser:
+      # pnpm --filter next-16-3-compat exec playwright install chromium
+      - name: Cache Playwright Chromium
+        uses: actions/cache@v4
+        id: playwright-cache
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-chromium-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            playwright-chromium-${{ runner.os }}-
+
       - name: Install Chromium
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: pnpm --filter next-16-3-compat exec playwright install --with-deps chromium
+
+      - name: Install Chromium OS dependencies
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: pnpm --filter next-16-3-compat exec playwright install-deps chromium
 
       - name: Test Instant Navigations
         run: pnpm --filter next-16-3-compat test:e2e

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,14 +2,14 @@
 
 ## Setup
 
-Install pnpm 11.x and Bun 1.3.x (pnpm manages dependencies; Bun runs tests and builds), then run:
+Install pnpm 11.x and Bun 1.3.x (pnpm manages dependencies; Bun runs tests and builds). Docs Vercel deploys also pin Bun 1.3.9 because `@wrksz/themes` minify uses `Bun.build` / bunup inside `pnpm --filter theme-docs build`. Then run:
 
 ```sh
 CI=true pnpm install --frozen-lockfile
 pnpm verify
 ```
 
-Use `pnpm verify:full` before requesting release review. It adds TypeScript 5.9/6/7 declaration checks, bundle comparison, production builds, dependency audit, and the Next.js Playwright fixture.
+Use `pnpm verify:full` before requesting release review. It adds TypeScript 5.9/6/7 declaration checks, bundle comparison, production builds, dependency audit, and the Next.js Playwright fixture. Install Chromium once with `pnpm --filter next-16-3-compat exec playwright install chromium`.
 
 ## Change expectations
 

--- a/apps/docs/vercel.json
+++ b/apps/docs/vercel.json
@@ -1,4 +1,4 @@
 {
 	"installCommand": "pnpm install --frozen-lockfile",
-	"buildCommand": "bunx bun@1.3.9 run build"
+	"buildCommand": "npm install --global bun@1.3.9 && pnpm --filter theme-docs build"
 }


### PR DESCRIPTION
## Summary
- Docs Vercel build now runs `pnpm --filter theme-docs build` (same as `apps/docs` `build`) while still pinning Bun 1.3.9 for bunup / `Bun.build` minify.
- CI `paths` include `README.md`, `CONTRIBUTING.md`, `AGENTS.md`, and `lefthook.yml`. The quality job skips Bun. The library job builds once, then `bun scripts/bundle-size.ts --compare` against the existing `dist`.
- Playwright Chromium is cached on the Next.js 16.3 fixture job; CONTRIBUTING notes the one-time local `playwright install chromium` for `verify:full`.

## Test plan
- [ ] Confirm CI quality job runs format/lint/audit without `setup-bun`.
- [ ] Confirm the library job runs a single `build` then one bundle-size compare (no extra rebuilds from `size` / `size:compare` scripts).
- [ ] Confirm a docs Vercel preview installs Bun 1.3.9 and completes `pnpm --filter theme-docs build`.
- [ ] Confirm the fixture job restores Playwright Chromium from cache on a second run.
- [ ] `pnpm format:check && pnpm lint` (already green locally). `ci.yml` parses as YAML.


Made with [Cursor](https://cursor.com)