### PR TITLE
feat(themes): pair createThemes with NextThemeProvider and ThemeScript

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ yarn-error.log*
 .env.production.local
 .turbo
 .next
+.worktrees/
 packages/themes/benchmarks/.bundle-size/
 
 .pnpm-store/

--- a/README.md
+++ b/README.md
@@ -307,6 +307,8 @@ export const { ThemeProvider, useTheme, useThemeValue, useThemeEffect } = create
 });
 ```
 
+For a Next.js root layout, import from `@wrksz/themes/next/create-themes` and use `NextThemeProvider` so the theme tuple is not copied into `@wrksz/themes/next`. Full API: [createThemes](https://themes.wrksz.dev/docs/api/create-themes).
+
 ### `ThemedImage`
 
 Shows different images per theme. Renders a transparent placeholder on the server to avoid hydration mismatches.
@@ -446,6 +448,7 @@ import { ThemedImage } from "@wrksz/themes/client/themed-image";
 import { ClientThemeProvider } from "@wrksz/themes/client/provider";
 import { ClientThemeProvider as ExtendedClientThemeProvider } from "@wrksz/themes/client/extended-provider";
 import { createThemes } from "@wrksz/themes/client/create-themes";
+import { createThemes as createNextThemes } from "@wrksz/themes/next/create-themes";
 ```
 
 | Import                                   | Use for                                                                                             |
@@ -460,6 +463,7 @@ import { createThemes } from "@wrksz/themes/client/create-themes";
 | `@wrksz/themes/client/provider`          | Direct `ClientThemeProvider` import                                                                 |
 | `@wrksz/themes/client/extended-provider` | Opt-in `ClientThemeProvider` with synchronization, mapping, and ShadowRoot support                  |
 | `@wrksz/themes/client/create-themes`     | Direct `createThemes` import                                                                        |
+| `@wrksz/themes/next/create-themes`       | Typed factory that also returns `NextThemeProvider` and `ThemeScript`                               |
 | `@wrksz/themes/next/extended`            | Opt-in Next.js `ThemeProvider` with synchronization and system mapping                              |
 | `@wrksz/themes`                          | Client-safe `ThemeProvider` alias and `createThemes` for framework-neutral React usage              |
 | `@wrksz/themes/script`                   | Server-safe `ThemeScript` for non-Next SSR frameworks                                               |

--- a/apps/docs/content/docs/api/create-themes.mdx
+++ b/apps/docs/content/docs/api/create-themes.mdx
@@ -27,7 +27,7 @@ export const { ThemeProvider, useTheme, useThemeValue, useThemeEffect, ThemedIma
 - `useThemeValue` maps are checked against your union (plus optional `default`).
 - `ThemedImage` requires a source for every configured theme.
 - Provider defaults can still be overridden per usage, while the theme tuple stays fixed.
-- The returned `ThemeProvider` is the **default client** provider. Use `@wrksz/themes/next` for the root Next.js provider that injects the anti-flash script.
+- The returned `ThemeProvider` is the **default client** provider. Use `@wrksz/themes/next` or `@wrksz/themes/next/create-themes` for the root Next.js provider that injects the anti-flash script.
 - `themeRoot`, `systemThemeMap`, and `enableSameDocumentSync` are not on the factory. Compose with [`@wrksz/themes/client/extended-provider`](/docs/api/client-theme-provider) when a subtree needs those props.
 
 ```tsx title="app/theme-toggle.tsx"
@@ -58,15 +58,62 @@ export function ThemeToggle() {
 }
 ```
 
+## Next.js root provider
+
+For App Router layouts, import the same factory from `@wrksz/themes/next/create-themes`. One config object yields the client pieces **and** a `NextThemeProvider` that injects the anti-flash script, so the layout does not re-list `themes`.
+
+```tsx title="app/theme.ts"
+"use client";
+import { createThemes } from "@wrksz/themes/next/create-themes";
+
+export const {
+  ThemeProvider,
+  NextThemeProvider,
+  ThemeScript,
+  useTheme,
+  useThemeValue,
+  useThemeEffect,
+  ThemedImage,
+} = createThemes({
+  themes: ["light", "dark", "high-contrast"] as const,
+  defaultTheme: "system",
+  storage: "hybrid",
+  disableTransitionOnChange: true,
+});
+```
+
+```tsx title="app/layout.tsx"
+import { NextThemeProvider } from "@/app/theme";
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en" suppressHydrationWarning>
+      <body>
+        <NextThemeProvider>{children}</NextThemeProvider>
+      </body>
+    </html>
+  );
+}
+```
+
+`createNextThemes` is the same function if you prefer that name. Keep using `ThemeProvider` from `@wrksz/themes/next` when you are not using the factory — that entry stays a thin wrapper and does not pull factory code.
+
+`ThemeScript` on the factory result is for non-Next SSR. It is typed to the same tuple. Next apps should prefer `NextThemeProvider` (`useServerInsertedHTML`) over mounting `ThemeScript` by hand.
+
 ## Return value
 
-`createThemes(config)` returns:
+`createThemes(config)` from `@wrksz/themes/client` returns:
 
 - `ThemeProvider`
 - `useTheme`
 - `useThemeValue`
 - `useThemeEffect`
 - `ThemedImage`
+
+`createThemes(config)` from `@wrksz/themes/next/create-themes` returns those plus:
+
+- `NextThemeProvider` — root Next.js provider with the anti-flash script, bound to the same context as `useTheme`
+- `ThemeScript` — typed bootstrap for non-Next SSR
 
 ## Exported types
 
@@ -95,6 +142,8 @@ export type AppThemeApi = CreateThemesResult<typeof themes>;
 export type AppThemeValueMap<Value> = ThemeValueMap<AppTheme, Value>;
 export type AppThemedImageProps = TypedThemedImageProps<AppTheme>;
 ```
+
+The Next factory also exports `CreateNextThemesResult`.
 
 ## Per-usage overrides
 
@@ -147,3 +196,11 @@ The resulting attributes are independent, for example `data-mode="dark"` and `da
 
 - Use `createThemes` for shipped app code with one canonical theme configuration.
 - Use `useTheme<T>()` for quick experiments and local prototypes.
+
+## Leaving beta
+
+Short 2.0 checklist for factory users:
+
+- **Default vs extended:** `createThemes` always binds the default provider. `systemThemeMap`, `themeRoot`, and `enableSameDocumentSync` stay on `@wrksz/themes/next/extended` and `@wrksz/themes/client/extended-provider`.
+- **Hybrid / SSR:** the pre-paint bootstrap reads the cookie. The Next provider does not call `cookies()`. Pass `initialTheme` from [`getTheme`](/docs/api/get-theme) only when server markup must know the theme.
+- **React 18+** is the public support floor (native `useEffectEvent` on React 19.2+).

--- a/apps/docs/content/docs/examples/typed-themes.mdx
+++ b/apps/docs/content/docs/examples/typed-themes.mdx
@@ -39,7 +39,7 @@ export function ThemeScope({ children }: { children: React.ReactNode }) {
 
 The `themes` tuple is fixed by the factory. Per-use props like `defaultTheme`, `forcedTheme`, `storageKey`, and `themeColor` can still be overridden, but the theme union remains consistent across the app.
 
-For a Next.js root layout with the anti-flash script, keep using `ThemeProvider` from `@wrksz/themes/next`.
+For a Next.js root layout with the anti-flash script, import `createThemes` from [`@wrksz/themes/next/create-themes`](/docs/api/create-themes#nextjs-root-provider) and use `NextThemeProvider`. Do not copy the `themes` array into `@wrksz/themes/next`.
 
 ## Build typed UI
 

--- a/apps/docs/content/docs/index.mdx
+++ b/apps/docs/content/docs/index.mdx
@@ -86,6 +86,7 @@ export function ThemeToggle() {
 | `@wrksz/themes/client/themed-image` | Direct `ThemedImage` import |
 | `@wrksz/themes/client/provider` | Direct `ClientThemeProvider` import |
 | `@wrksz/themes/client/create-themes` | Direct `createThemes` import |
+| `@wrksz/themes/next/create-themes` | Typed `createThemes` with `NextThemeProvider` and `ThemeScript` |
 | `@wrksz/themes/next/extended` | Opt-in Next.js `ThemeProvider` with `systemThemeMap` and same-document sync |
 | `@wrksz/themes/client/extended-provider` | Opt-in `ClientThemeProvider` with `themeRoot`, `systemThemeMap`, and same-document sync |
 | `@wrksz/themes` | Client-safe `ThemeProvider` alias and `createThemes` for framework-neutral React usage |

--- a/apps/docs/content/docs/migration.mdx
+++ b/apps/docs/content/docs/migration.mdx
@@ -171,7 +171,7 @@ After migrating, these features are available without any additional configurati
 - **`initialTheme`** - initialize theme from a server-side source.
 - **`followSystem`** - always follow system preference, ignoring stored value.
 - **`getTheme()`** - read the current theme from a cookie outside React.
-- **`createThemes(...)`** - typed factory for provider + hooks from one canonical theme tuple.
+- **`createThemes(...)`** - typed factory for provider + hooks from one canonical theme tuple. Use `@wrksz/themes/next/create-themes` when the root layout needs `NextThemeProvider` without re-listing the tuple.
 - **`useThemeEffect(...)`** - side effects that run on theme changes after mount.
 
 See [Why not next-themes?](/docs/why-not-next-themes) for the full comparison.

--- a/packages/themes/README.md
+++ b/packages/themes/README.md
@@ -112,6 +112,7 @@ import { useHydrated } from "@wrksz/themes/client/use-hydrated";
 import { ThemedImage } from "@wrksz/themes/client/themed-image";
 import { ClientThemeProvider } from "@wrksz/themes/client/provider";
 import { createThemes } from "@wrksz/themes/client/create-themes";
+import { createThemes as createNextThemes } from "@wrksz/themes/next/create-themes";
 ```
 
 Full API docs and examples live at [themes.wrksz.dev](https://themes.wrksz.dev).

--- a/packages/themes/build-entries.ts
+++ b/packages/themes/build-entries.ts
@@ -11,6 +11,7 @@ export const PUBLIC_BUILD_ENTRIES: readonly string[] = [
 	"src/client/create-themes.ts",
 	"src/next.ts",
 	"src/next/extended.ts",
+	"src/next/create-themes.ts",
 	"src/script.ts",
 ];
 

--- a/packages/themes/package.json
+++ b/packages/themes/package.json
@@ -88,6 +88,12 @@
 				"default": "./dist/next/extended.js"
 			}
 		},
+		"./next/create-themes": {
+			"import": {
+				"types": "./dist/next/create-themes.d.ts",
+				"default": "./dist/next/create-themes.js"
+			}
+		},
 		"./script": {
 			"import": {
 				"types": "./dist/script.d.ts",

--- a/packages/themes/scripts/smoke-exports.ts
+++ b/packages/themes/scripts/smoke-exports.ts
@@ -9,6 +9,7 @@ import * as useTheme from "@wrksz/themes/client/use-theme";
 import * as useThemeEffect from "@wrksz/themes/client/use-theme-effect";
 import * as useThemeValue from "@wrksz/themes/client/use-theme-value";
 import * as next from "@wrksz/themes/next";
+import * as nextCreateThemes from "@wrksz/themes/next/create-themes";
 import * as nextExtended from "@wrksz/themes/next/extended";
 import * as script from "@wrksz/themes/script";
 
@@ -24,6 +25,7 @@ const entrypoints = [
 	["./client/use-theme-effect", useThemeEffect, ["useThemeEffect"]],
 	["./client/use-theme-value", useThemeValue, ["useThemeValue"]],
 	["./next", next, ["ThemeProvider", "getTheme"]],
+	["./next/create-themes", nextCreateThemes, ["createThemes", "createNextThemes"]],
 	["./next/extended", nextExtended, ["ThemeProvider"]],
 	["./script", script, ["ThemeScript"]],
 ] as const;

--- a/packages/themes/src/__tests__/client-subpath-exports.test.ts
+++ b/packages/themes/src/__tests__/client-subpath-exports.test.ts
@@ -44,6 +44,7 @@ describe("client subpath exports", () => {
 			expect(buildEntries).toContain(`"src/client/${subpath}.ts"`);
 		}
 		expect(buildEntries).toContain('"src/next/extended.ts"');
+		expect(buildEntries).toContain('"src/next/create-themes.ts"');
 		expect(buildEntries).toContain('"src/providers/extended-client-next-provider.tsx"');
 	});
 
@@ -56,6 +57,19 @@ describe("client subpath exports", () => {
 			import: {
 				types: "./dist/next/extended.d.ts",
 				default: "./dist/next/extended.js",
+			},
+		});
+	});
+
+	test("package.json exposes the Next createThemes factory", () => {
+		const packageJson = JSON.parse(readFileSync(resolve(rootDir, "package.json"), "utf-8")) as {
+			exports: Record<string, { import?: { types?: string; default?: string } }>;
+		};
+
+		expect(packageJson.exports["./next/create-themes"]).toEqual({
+			import: {
+				types: "./dist/next/create-themes.d.ts",
+				default: "./dist/next/create-themes.js",
 			},
 		});
 	});

--- a/packages/themes/src/__tests__/create-next-themes.test.tsx
+++ b/packages/themes/src/__tests__/create-next-themes.test.tsx
@@ -1,0 +1,119 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import "./setup.js";
+import { act, cleanup, fireEvent, render } from "@testing-library/react";
+import { isValidElement, type ReactElement, type ReactNode } from "react";
+import { clearCookies } from "./setup.js";
+
+const insertedHtmlCallbacks: Array<() => ReactNode> = [];
+
+mock.module("next/navigation", () => ({
+	useServerInsertedHTML: (callback: () => ReactNode) => {
+		insertedHtmlCallbacks.push(callback);
+	},
+}));
+
+const { createThemes } = await import("../factory/create-next-themes.js");
+
+const { NextThemeProvider, ThemeProvider, ThemeScript, useTheme } = createThemes({
+	themes: ["light", "dark", "sepia"] as const,
+	defaultTheme: "light",
+	attribute: "class",
+	storage: "none",
+});
+
+function ThemeReader() {
+	const { theme, setTheme } = useTheme();
+	return (
+		<div>
+			<span data-testid="theme">{theme ?? "-"}</span>
+			<button type="button" data-testid="set-sepia" onClick={() => setTheme("sepia")}>
+				set-sepia
+			</button>
+		</div>
+	);
+}
+
+type ScriptElement = ReactElement<{
+	dangerouslySetInnerHTML?: { __html?: string };
+	nonce?: string;
+	suppressHydrationWarning?: boolean;
+}>;
+
+beforeEach(() => {
+	document.documentElement.className = "";
+	document.documentElement.removeAttribute("data-theme");
+	document.documentElement.style.colorScheme = "";
+	localStorage.clear();
+	sessionStorage.clear();
+	clearCookies();
+	window.matchMedia = () =>
+		({
+			matches: false,
+			addEventListener: () => {},
+			removeEventListener: () => {},
+		}) as unknown as MediaQueryList;
+});
+
+afterEach(() => {
+	cleanup();
+	insertedHtmlCallbacks.length = 0;
+	localStorage.clear();
+	sessionStorage.clear();
+	clearCookies();
+});
+
+describe("createThemes Next pairing", () => {
+	test("NextThemeProvider injects a bootstrap that includes the factory theme tuple", () => {
+		render(
+			<NextThemeProvider>
+				<ThemeReader />
+			</NextThemeProvider>,
+		);
+
+		const callback = insertedHtmlCallbacks[0];
+		expect(callback).toBeDefined();
+		const script = callback?.();
+		expect(isValidElement(script)).toBe(true);
+		expect((script as ScriptElement).type).toBe("script");
+		expect((script as ScriptElement).props.dangerouslySetInnerHTML?.__html).toContain(
+			'"sepia"',
+		);
+		expect((script as ScriptElement).props.dangerouslySetInnerHTML?.__html).toContain(
+			'"light"',
+		);
+	});
+
+	test("factory useTheme reads the NextThemeProvider context", () => {
+		const view = render(
+			<NextThemeProvider>
+				<ThemeReader />
+			</NextThemeProvider>,
+		);
+
+		expect(view.getByTestId("theme").textContent).toBe("light");
+
+		act(() => {
+			fireEvent.click(view.getByTestId("set-sepia"));
+		});
+
+		expect(view.getByTestId("theme").textContent).toBe("sepia");
+	});
+
+	test("client ThemeProvider from the same factory still works without the Next wrapper", () => {
+		const view = render(
+			<ThemeProvider>
+				<ThemeReader />
+			</ThemeProvider>,
+		);
+
+		expect(view.getByTestId("theme").textContent).toBe("light");
+	});
+
+	test("ThemeScript uses the factory theme tuple without a second themes array", () => {
+		const view = render(<ThemeScript />);
+		const script = view.container.querySelector("script");
+		expect(script?.textContent).toContain('"sepia"');
+		expect(script?.textContent).toContain('"light"');
+		expect(script?.textContent).not.toContain("__name");
+	});
+});

--- a/packages/themes/src/__tests__/type-inference.tsx
+++ b/packages/themes/src/__tests__/type-inference.tsx
@@ -15,6 +15,10 @@ import {
 	type TypedThemedImageProps,
 } from "../index.js";
 import { type GetThemeOptions, getTheme } from "../next.js";
+import {
+	createThemes as createNextThemes,
+	type CreateNextThemesResult,
+} from "../next/create-themes.js";
 
 function expectType<T>(_value: T): void {}
 
@@ -219,3 +223,47 @@ function InvalidTypedImage(): ReactNode {
 	);
 }
 expectType<() => ReactNode>(InvalidTypedImage);
+
+const nextTyped = createNextThemes({
+	themes: appThemes,
+	storage: "hybrid",
+	defaultTheme: "system",
+});
+expectType<CreateNextThemesResult<typeof appThemes>>(nextTyped);
+expectType<CreateThemesResult<typeof appThemes>>(nextTyped);
+
+function NextTypedUsage(): ReactNode {
+	const { setTheme } = nextTyped.useTheme();
+	setTheme("high-contrast");
+	// @ts-expect-error setTheme only accepts configured themes or "system"
+	setTheme("sepia");
+	return (
+		<nextTyped.NextThemeProvider defaultTheme="high-contrast">
+			<nextTyped.ThemeScript nonce="theme-script" />
+			children
+		</nextTyped.NextThemeProvider>
+	);
+}
+expectType<() => ReactNode>(NextTypedUsage);
+
+function InvalidNextProviderOverride(): ReactNode {
+	return (
+		<nextTyped.NextThemeProvider
+			// @ts-expect-error typed NextThemeProvider keeps the configured theme tuple fixed
+			themes={["light", "dark"] as const}
+		>
+			children
+		</nextTyped.NextThemeProvider>
+	);
+}
+expectType<() => ReactNode>(InvalidNextProviderOverride);
+
+function InvalidNextScriptOverride(): ReactNode {
+	return (
+		<nextTyped.ThemeScript
+			// @ts-expect-error typed ThemeScript keeps the configured theme tuple fixed
+			themes={["light", "dark"] as const}
+		/>
+	);
+}
+expectType<() => ReactNode>(InvalidNextScriptOverride);

--- a/packages/themes/src/factory/create-next-themes.tsx
+++ b/packages/themes/src/factory/create-next-themes.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import type { ReactElement } from "react";
+import type { ThemeContextInstance } from "../core/context.js";
+import type { ThemeProviderProps } from "../core/types.js";
+import { ClientNextThemeProvider } from "../providers/client-next-provider.js";
+import { ThemeScript, type ThemeScriptProps } from "../theme-script.js";
+import {
+	type CreateThemesConfig,
+	type CreateThemesResult,
+	createThemesBindings,
+} from "./create-themes.js";
+
+export type {
+	CreateThemesConfig,
+	CreateThemesResult,
+	ThemeValueMap,
+	TypedThemedImageProps,
+} from "./create-themes.js";
+export type { ThemeScriptProps } from "../theme-script.js";
+
+export type CreateNextThemesResult<Themes extends readonly string[]> =
+	CreateThemesResult<Themes> & {
+		NextThemeProvider: (
+			props: Omit<ThemeProviderProps<Themes[number]>, "themes">,
+		) => ReactElement;
+		ThemeScript: (props?: Omit<ThemeScriptProps<Themes[number]>, "themes">) => ReactElement;
+	};
+
+type NextProviderProps<Themes extends string> = Omit<ThemeProviderProps<Themes>, "themes"> & {
+	themes: readonly Themes[];
+	themeContext: ThemeContextInstance<Themes>;
+};
+
+function toThemeScriptProps<Themes extends readonly string[]>(
+	config: CreateThemesConfig<Themes>,
+): Omit<ThemeScriptProps<Themes[number]>, "themes"> {
+	const {
+		onThemeChange: _onThemeChange,
+		onStorageError: _onStorageError,
+		cookieOptions: _cookieOptions,
+		themes: _themes,
+		...scriptDefaults
+	} = config;
+	return scriptDefaults;
+}
+
+export function createThemes<const Themes extends readonly [string, ...string[]]>(
+	config: CreateThemesConfig<Themes>,
+): CreateNextThemesResult<Themes> {
+	const bindings = createThemesBindings(config);
+	const scriptDefaults = toThemeScriptProps(config);
+	type ThemeName = Themes[number];
+
+	function TypedNextThemeProvider(
+		props: Omit<ThemeProviderProps<ThemeName>, "themes">,
+	): ReactElement {
+		const merged = {
+			...config,
+			...props,
+			themes: config.themes,
+			themeContext: bindings.themeContext,
+		} satisfies NextProviderProps<ThemeName>;
+		return <ClientNextThemeProvider {...merged} />;
+	}
+
+	function TypedThemeScript(
+		props: Omit<ThemeScriptProps<ThemeName>, "themes"> = {},
+	): ReactElement {
+		return <ThemeScript {...scriptDefaults} {...props} themes={config.themes} />;
+	}
+
+	return {
+		ThemeProvider: bindings.ThemeProvider,
+		NextThemeProvider: TypedNextThemeProvider,
+		ThemeScript: TypedThemeScript,
+		useTheme: bindings.useTheme,
+		useThemeValue: bindings.useThemeValue,
+		useThemeEffect: bindings.useThemeEffect,
+		ThemedImage: bindings.ThemedImage,
+	};
+}
+
+export const createNextThemes: typeof createThemes = createThemes;

--- a/packages/themes/src/factory/create-themes.tsx
+++ b/packages/themes/src/factory/create-themes.tsx
@@ -9,7 +9,11 @@ import {
 } from "react";
 import type { ThemedImageProps } from "../components/themed-image.js";
 import { ThemedImage } from "../components/themed-image.js";
-import { createThemeContext, useThemeFromContext } from "../core/context.js";
+import {
+	createThemeContext,
+	type ThemeContextInstance,
+	useThemeFromContext,
+} from "../core/context.js";
 import { resolveThemeValue, type ThemeValueMap } from "../core/theme-value.js";
 import type {
 	ResolvedTheme,
@@ -45,9 +49,14 @@ export type CreateThemesResult<Themes extends readonly string[]> = {
 	ThemedImage: (props: TypedThemedImageProps<Themes[number]>) => ReactElement;
 };
 
-export function createThemes<const Themes extends readonly [string, ...string[]]>(
+/** Isolated factory bindings. Not a public export — used by the Next factory to share context. */
+export type CreateThemesBindings<Themes extends readonly string[]> = CreateThemesResult<Themes> & {
+	themeContext: ThemeContextInstance<Themes[number]>;
+};
+
+export function createThemesBindings<const Themes extends readonly [string, ...string[]]>(
 	config: CreateThemesConfig<Themes>,
-): CreateThemesResult<Themes> {
+): CreateThemesBindings<Themes> {
 	const defaults = config;
 	type ThemeName = Themes[number];
 	const context = createThemeContext<ThemeName>();
@@ -97,10 +106,24 @@ export function createThemes<const Themes extends readonly [string, ...string[]]
 	}
 
 	return {
+		themeContext: context,
 		ThemeProvider: TypedThemeProvider,
 		useTheme: useTypedTheme,
 		useThemeValue: useTypedThemeValue,
 		useThemeEffect: useTypedThemeEffect,
 		ThemedImage: TypedThemedImage,
+	};
+}
+
+export function createThemes<const Themes extends readonly [string, ...string[]]>(
+	config: CreateThemesConfig<Themes>,
+): CreateThemesResult<Themes> {
+	const bindings = createThemesBindings(config);
+	return {
+		ThemeProvider: bindings.ThemeProvider,
+		useTheme: bindings.useTheme,
+		useThemeValue: bindings.useThemeValue,
+		useThemeEffect: bindings.useThemeEffect,
+		ThemedImage: bindings.ThemedImage,
 	};
 }

--- a/packages/themes/src/next/create-themes.ts
+++ b/packages/themes/src/next/create-themes.ts
@@ -1,0 +1,11 @@
+"use client";
+
+export type {
+	CreateNextThemesResult,
+	CreateThemesConfig,
+	CreateThemesResult,
+	ThemeScriptProps,
+	ThemeValueMap,
+	TypedThemedImageProps,
+} from "../factory/create-next-themes.js";
+export { createNextThemes, createThemes } from "../factory/create-next-themes.js";

--- a/packages/themes/src/providers/client-next-provider.tsx
+++ b/packages/themes/src/providers/client-next-provider.tsx
@@ -3,13 +3,13 @@ import { useServerInsertedHTML } from "next/navigation";
 import { type ReactElement, useEffect, useRef } from "react";
 import { getScript } from "../core/script.js";
 import { resolveDefaultTheme } from "../core/theme-validation.js";
-import type { DefaultTheme, ThemeProviderProps } from "../core/types.js";
-import { ClientThemeProvider } from "./client-provider.js";
+import type { DefaultTheme } from "../core/types.js";
+import { type ClientThemeProviderProps, ClientThemeProvider } from "./client-provider.js";
 
 const DEFAULT_THEMES: string[] = ["light", "dark"];
 
 export function ClientNextThemeProvider<Themes extends string = DefaultTheme>(
-	props: ThemeProviderProps<Themes>,
+	props: ClientThemeProviderProps<Themes>,
 ): ReactElement {
 	const {
 		themes = DEFAULT_THEMES as Themes[],

--- a/packages/themes/test-d/public-api.tsx
+++ b/packages/themes/test-d/public-api.tsx
@@ -30,6 +30,10 @@ import type {
 	ThemeProviderProps,
 } from "@wrksz/themes";
 import { getTheme, ThemeProvider as NextThemeProvider } from "@wrksz/themes/next";
+import {
+	createNextThemes,
+	createThemes as createNextCreateThemes,
+} from "@wrksz/themes/next/create-themes";
 import { ThemeScript } from "@wrksz/themes/script";
 
 const themes = ["light", "dark", "high-contrast"] as const;
@@ -43,6 +47,15 @@ const configured = createThemes({
 		dark: "#000",
 		"high-contrast": "#ff0",
 	},
+});
+
+const nextConfigured = createNextCreateThemes({
+	themes,
+	defaultTheme: "system",
+});
+const nextAlias = createNextThemes({
+	themes,
+	defaultTheme: "light",
 });
 
 const providerProps = {
@@ -89,6 +102,8 @@ const syncTheme = getTheme(new Request("https://example.com"), {
 	defaultTheme: "light",
 });
 const checkedTheme: AppTheme = syncTheme;
+const nextThemeScript = nextConfigured.ThemeScript();
+const nextRoot = <nextAlias.NextThemeProvider>{nextThemeScript}</nextAlias.NextThemeProvider>;
 
 export {
 	checkedTheme,
@@ -97,6 +112,9 @@ export {
 	configured,
 	createRootThemes,
 	createThemesSubpath,
+	nextAlias,
+	nextConfigured,
+	nextRoot,
 	NextThemeProvider,
 	providerProps,
 	RootThemeProvider,


### PR DESCRIPTION
## Summary
- `@wrksz/themes/next/create-themes` returns the existing typed client pieces plus `NextThemeProvider` and `ThemeScript`, so a Next layout does not re-list the theme tuple. `createNextThemes` is the same function.
- Default `@wrksz/themes/next` / `@wrksz/themes/client` stay thin: factory code is a separate export. `systemThemeMap`, `themeRoot`, and `enableSameDocumentSync` stay on extended entries, not the default factory.
- Independent of #92. `create-themes.mdx` also carries the #89 “default client / not extended” copy — rebase if that file conflicts.

## Test plan
- [ ] `pnpm --filter @wrksz/themes test`
- [ ] `pnpm --filter @wrksz/themes size:compare` (next-provider raw delta 0 B; gzip +3 B noise)
- [ ] Import `@wrksz/themes/next` in a layout without `createThemes` and confirm the anti-flash script is unchanged
- [ ] Import `createThemes` from `@wrksz/themes/next/create-themes`, wrap with `NextThemeProvider`, and toggle via factory `useTheme` without copying `themes`


Made with [Cursor](https://cursor.com)