### PR TITLE
feat: export framework-neutral getTheme from @wrksz/themes/server

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,17 +234,19 @@ const { theme, setTheme } = useTheme<AppTheme>();
 
 ### `getTheme`
 
-Reads the current theme from a cookie outside React. Available in `@wrksz/themes/next`.
+Reads the current theme from a cookie outside React. Use [`@wrksz/themes/server`](https://themes.wrksz.dev/docs/api/get-theme) for the `Request` helper (Remix, TanStack, Vite). `@wrksz/themes/next` re-exports it and adds `await getTheme()` via `cookies()`.
 
 ```ts
-// proxy.ts - sync, reads from Request
-import { getTheme } from "@wrksz/themes/next";
+// Request — any SSR framework
+import { getTheme } from "@wrksz/themes/server";
 
-export function proxy(request: Request) {
+export function loader({ request }: { request: Request }) {
   const theme = getTheme(request, { defaultTheme: "dark" });
 }
 
-// layout.tsx - async, reads via cookies() from next/headers
+// Next.js layout — async, reads via cookies() from next/headers
+import { getTheme } from "@wrksz/themes/next";
+
 const theme = await getTheme({ defaultTheme: "dark" });
 return <html className={theme}>...</html>;
 ```
@@ -454,6 +456,8 @@ import { createThemes as createNextThemes } from "@wrksz/themes/next/create-them
 | Import                                   | Use for                                                                                             |
 | ---------------------------------------- | --------------------------------------------------------------------------------------------------- |
 | `@wrksz/themes/next`                     | `ThemeProvider`, `getTheme` in Next.js (recommended)                                                |
+| `@wrksz/themes/server`                   | Framework-neutral `getTheme(request)` and `parseThemeCookie`                                        |
+| `@wrksz/themes/script`                   | Server-safe `ThemeScript` for non-Next SSR frameworks                                               |
 | `@wrksz/themes/client`                   | `useTheme`, `useThemeValue`, `useThemeEffect`, `createThemes`, `ThemedImage`, `ClientThemeProvider` |
 | `@wrksz/themes/client/use-theme`         | Direct `useTheme` import                                                                            |
 | `@wrksz/themes/client/use-theme-value`   | Direct `useThemeValue` import                                                                       |
@@ -466,7 +470,6 @@ import { createThemes as createNextThemes } from "@wrksz/themes/next/create-them
 | `@wrksz/themes/next/create-themes`       | Typed factory that also returns `NextThemeProvider` and `ThemeScript`                               |
 | `@wrksz/themes/next/extended`            | Opt-in Next.js `ThemeProvider` with synchronization and system mapping                              |
 | `@wrksz/themes`                          | Client-safe `ThemeProvider` alias and `createThemes` for framework-neutral React usage              |
-| `@wrksz/themes/script`                   | Server-safe `ThemeScript` for non-Next SSR frameworks                                               |
 
 ## License
 

--- a/apps/docs/content/docs/api/get-theme.mdx
+++ b/apps/docs/content/docs/api/get-theme.mdx
@@ -3,18 +3,54 @@ title: getTheme
 description: Read the current theme from a cookie outside React - in proxy, layouts, or server actions.
 ---
 
-`getTheme` reads the current theme from a cookie. Available in `@wrksz/themes/next`.
+`getTheme` reads the current theme from a cookie. Use `@wrksz/themes/server` for the framework-neutral `Request` helper and `parseThemeCookie`. `@wrksz/themes/next` re-exports `getTheme` with an extra async overload that reads `cookies()` from `next/headers`.
 
 <Callout type="warn">
   <Breaking /> In **`2.0.0-beta.1`**, `ThemeProvider` no longer calls `getTheme` / `cookies()` for you. Use this helper only when server markup must know the theme. See [Upgrading from 1.x](/docs/migration#upgrading-from-1x).
 </Callout>
 
-Two variants depending on context:
+| Call | Import | Returns | Use when |
+|------|--------|---------|----------|
+| `getTheme(request)` | `@wrksz/themes/server` or `@wrksz/themes/next` | `string` or inferred theme union | Remix, TanStack Start, Vite, `proxy.ts`, edge functions |
+| `parseThemeCookie(cookieHeader)` | `@wrksz/themes/server` | `string` or inferred theme union | Loaders that already have a `Cookie` header string |
+| `await getTheme()` | `@wrksz/themes/next` | `Promise<string>` or inferred theme union | Next.js Server Components, layouts |
 
-| Call | Returns | Use when |
-|------|---------|----------|
-| `getTheme(request)` | `string` or inferred theme union | `proxy.ts`, edge functions |
-| `await getTheme()` | `Promise<string>` or inferred theme union | Server Components, layouts |
+## Other frameworks
+
+```tsx title="root.tsx"
+import { ThemeScript } from "@wrksz/themes/script";
+import { getTheme } from "@wrksz/themes/server";
+import { ThemeProvider } from "@wrksz/themes";
+
+export function Document({
+  children,
+  request,
+}: {
+  children: React.ReactNode;
+  request: Request;
+}) {
+  const theme = getTheme(request, { defaultTheme: "dark" });
+
+  return (
+    <html className={theme} suppressHydrationWarning>
+      <head>
+        <ThemeScript defaultTheme="dark" />
+      </head>
+      <body>
+        <ThemeProvider defaultTheme="dark">{children}</ThemeProvider>
+      </body>
+    </html>
+  );
+}
+```
+
+If you have a cookie header string instead of a `Request`:
+
+```ts
+import { parseThemeCookie } from "@wrksz/themes/server";
+
+const theme = parseThemeCookie(cookieHeader, { defaultTheme: "dark" });
+```
 
 ## Proxy
 

--- a/apps/docs/content/docs/examples/framework-agnostic.mdx
+++ b/apps/docs/content/docs/examples/framework-agnostic.mdx
@@ -3,15 +3,24 @@ title: Other React frameworks
 description: First-paint theming in TanStack Start, Remix, and other SSR frameworks.
 ---
 
-Use the client provider for state and render `ThemeScript` in your framework's server-controlled document head.
+Use the client provider for state and render `ThemeScript` in your framework's server-controlled document head. When server-rendered markup must include the theme class, read the cookie with `getTheme` from `@wrksz/themes/server` — do not import `@wrksz/themes/next`.
 
 ```tsx
 import { ThemeScript } from "@wrksz/themes/script";
+import { getTheme } from "@wrksz/themes/server";
 import { ThemeProvider } from "@wrksz/themes";
 
-export function Document({ children }: { children: React.ReactNode }) {
+export function Document({
+  children,
+  request,
+}: {
+  children: React.ReactNode;
+  request: Request;
+}) {
+  const theme = getTheme(request, { defaultTheme: "system" });
+
   return (
-    <html suppressHydrationWarning>
+    <html className={theme} suppressHydrationWarning>
       <head>
         <ThemeScript />
       </head>
@@ -21,6 +30,14 @@ export function Document({ children }: { children: React.ReactNode }) {
     </html>
   );
 }
+```
+
+If the loader gives you a `Cookie` header string instead of a `Request`:
+
+```ts
+import { parseThemeCookie } from "@wrksz/themes/server";
+
+const theme = parseThemeCookie(cookieHeader, { defaultTheme: "dark" });
 ```
 
 `ThemeScript` and `getScript` use a build-generated deterministic bootstrap so bundlers cannot rewrite behavior through `Function#toString()`. Keep script configuration equal to the provider configuration. `ThemeScript` / `getScript` cannot take `themeRoot`: Shadow widgets stay on `@wrksz/themes/client/extended-provider` after mount. See [Shadow DOM](/docs/examples/shadow-dom).

--- a/apps/docs/content/docs/index.mdx
+++ b/apps/docs/content/docs/index.mdx
@@ -78,7 +78,9 @@ export function ThemeToggle() {
 
 | Import | Use for |
 |--------|---------|
-| `@wrksz/themes/next` | `ThemeProvider` in Next.js (recommended) |
+| `@wrksz/themes/next` | `ThemeProvider` and `getTheme` in Next.js (recommended) |
+| `@wrksz/themes/server` | Framework-neutral `getTheme(request)` and `parseThemeCookie` |
+| `@wrksz/themes/script` | Server-safe `ThemeScript` for non-Next SSR frameworks |
 | `@wrksz/themes/client` | `useTheme`, `useThemeValue`, `useThemeEffect`, `ThemedImage`, `ClientThemeProvider`, `createThemes` |
 | `@wrksz/themes/client/use-theme` | Direct `useTheme` import |
 | `@wrksz/themes/client/use-theme-value` | Direct `useThemeValue` import |

--- a/packages/themes/README.md
+++ b/packages/themes/README.md
@@ -90,6 +90,7 @@ wrap request-time themed subtrees in `Suspense` or set `export const instant = f
 
 ```tsx
 import { ThemeProvider, getTheme } from "@wrksz/themes/next";
+import { getTheme as getThemeFromRequest, parseThemeCookie } from "@wrksz/themes/server";
 import {
 	ClientThemeProvider,
 	ThemedImage,

--- a/packages/themes/build-entries.ts
+++ b/packages/themes/build-entries.ts
@@ -13,6 +13,7 @@ export const PUBLIC_BUILD_ENTRIES: readonly string[] = [
 	"src/next/extended.ts",
 	"src/next/create-themes.ts",
 	"src/script.ts",
+	"src/server.ts",
 ];
 
 export const INTERNAL_RUNTIME_BUILD_ENTRIES: readonly string[] = [

--- a/packages/themes/package.json
+++ b/packages/themes/package.json
@@ -100,6 +100,12 @@
 				"default": "./dist/script.js"
 			}
 		},
+		"./server": {
+			"import": {
+				"types": "./dist/server.d.ts",
+				"default": "./dist/server.js"
+			}
+		},
 		"./package.json": "./package.json"
 	},
 	"scripts": {

--- a/packages/themes/scripts/smoke-exports.ts
+++ b/packages/themes/scripts/smoke-exports.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from "node:fs";
 import * as root from "@wrksz/themes";
 import * as client from "@wrksz/themes/client";
 import * as createThemes from "@wrksz/themes/client/create-themes";
@@ -12,6 +13,7 @@ import * as next from "@wrksz/themes/next";
 import * as nextCreateThemes from "@wrksz/themes/next/create-themes";
 import * as nextExtended from "@wrksz/themes/next/extended";
 import * as script from "@wrksz/themes/script";
+import * as server from "@wrksz/themes/server";
 
 const entrypoints = [
 	[".", root, ["ThemeProvider", "createThemes"]],
@@ -28,6 +30,7 @@ const entrypoints = [
 	["./next/create-themes", nextCreateThemes, ["createThemes", "createNextThemes"]],
 	["./next/extended", nextExtended, ["ThemeProvider"]],
 	["./script", script, ["ThemeScript"]],
+	["./server", server, ["getTheme", "parseThemeCookie"]],
 ] as const;
 
 for (const [subpath, module, expectedExports] of entrypoints) {
@@ -38,4 +41,9 @@ for (const [subpath, module, expectedExports] of entrypoints) {
 			);
 		}
 	}
+}
+
+const serverBundle = readFileSync(new URL("../dist/server.js", import.meta.url), "utf8");
+if (serverBundle.includes("next/headers")) {
+	throw new Error("@wrksz/themes/server must not reference next/headers");
 }

--- a/packages/themes/src/__tests__/client-subpath-exports.test.ts
+++ b/packages/themes/src/__tests__/client-subpath-exports.test.ts
@@ -86,6 +86,18 @@ describe("client subpath exports", () => {
 		});
 	});
 
+	test("exposes the framework-neutral server entrypoint", () => {
+		const packageJson = JSON.parse(readFileSync(resolve(rootDir, "package.json"), "utf-8")) as {
+			exports: Record<string, { import?: { types?: string; default?: string } }>;
+		};
+		expect(packageJson.exports["./server"]).toEqual({
+			import: {
+				types: "./dist/server.d.ts",
+				default: "./dist/server.js",
+			},
+		});
+	});
+
 	test("keeps every public export in build, declaration, and smoke coverage", () => {
 		const packageJson = JSON.parse(readFileSync(resolve(rootDir, "package.json"), "utf-8")) as {
 			exports: Record<string, { import?: { types?: string; default?: string } } | string>;

--- a/packages/themes/src/__tests__/get-theme.test.ts
+++ b/packages/themes/src/__tests__/get-theme.test.ts
@@ -1,31 +1,15 @@
-import { beforeEach, describe, expect, mock, test } from "bun:test";
-import { getTheme } from "../get-theme.js";
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { getTheme, parseThemeCookie } from "../get-theme.js";
 
-let nextCookieValue: string | undefined;
-let nextCookieReads = 0;
-
-mock.module("next/headers", () => ({
-	cookies: async () => {
-		nextCookieReads += 1;
-		return {
-			get: (_key: string) =>
-				nextCookieValue === undefined
-					? undefined
-					: { name: "theme", value: nextCookieValue },
-		};
-	},
-}));
+const srcDir = resolve(import.meta.dir, "..");
 
 function makeRequest(cookieHeader: string): Request {
 	return new Request("https://example.com", {
 		headers: { cookie: cookieHeader },
 	});
 }
-
-beforeEach(() => {
-	nextCookieValue = undefined;
-	nextCookieReads = 0;
-});
 
 describe("getTheme - sync (Request)", () => {
 	test("returns stored theme from cookie", () => {
@@ -82,93 +66,66 @@ describe("getTheme - sync (Request)", () => {
 	});
 });
 
-describe("getTheme - async (no Request)", () => {
-	test("returns defaultTheme when the cookie is absent", async () => {
-		expect(await getTheme({ defaultTheme: "dark" })).toBe("dark");
+describe("parseThemeCookie", () => {
+	test("returns stored theme from cookie header", () => {
+		expect(parseThemeCookie("theme=dark")).toBe("dark");
 	});
 
-	test("returns 'system' as default when no options provided", async () => {
-		expect(await getTheme()).toBe("system");
+	test("returns defaultTheme when cookie is absent", () => {
+		expect(parseThemeCookie("", { defaultTheme: "dark" })).toBe("dark");
 	});
 
-	test("returns a valid stored theme", async () => {
-		nextCookieValue = "dark";
-		expect(await getTheme({ themes: ["light", "dark"] })).toBe("dark");
+	test("returns 'system' as default when no defaultTheme provided", () => {
+		expect(parseThemeCookie("")).toBe("system");
 	});
 
-	test("accepts system when a themes allowlist is provided", async () => {
-		nextCookieValue = "system";
-		expect(await getTheme({ themes: ["light", "dark"] })).toBe("system");
+	test("uses custom storageKey", () => {
+		expect(parseThemeCookie("app-theme=light", { storageKey: "app-theme" })).toBe("light");
 	});
 
-	test("returns defaultTheme for unknown, encoded, or malformed values outside the allowlist", async () => {
-		for (const stored of ["unknown", "high%2Dcontrast", "%E0%A4%A"]) {
-			nextCookieValue = stored;
-			expect(
-				await getTheme({
-					themes: ["light", "dark"],
-					defaultTheme: "light",
-				}),
-			).toBe("light");
-		}
-	});
-});
-
-describe("Next ThemeProvider App Shell behavior", () => {
-	test("leaves cookie reads to the pre-hydration script", async () => {
-		nextCookieValue = "dark";
-		const { ThemeProvider } = await import("../providers/next-provider.js");
-		const element = ThemeProvider({
-			children: null,
-			storage: "cookie",
-			themes: ["light", "dark"],
-		});
-
-		expect(nextCookieReads).toBe(0);
-		expect((element.props as { storage?: string }).storage).toBe("cookie");
-		expect((element.props as { initialTheme?: string }).initialTheme).toBeUndefined();
+	test("ignores stored value not in themes list", () => {
+		expect(
+			parseThemeCookie("theme=unknown", {
+				themes: ["light", "dark"],
+				defaultTheme: "light",
+			}),
+		).toBe("light");
 	});
 
-	test("preserves an explicit initialTheme without reading request data", async () => {
-		const { ThemeProvider } = await import("../providers/next-provider.js");
-		const element = ThemeProvider({
-			children: null,
-			storage: "cookie",
-			themes: ["light", "dark"],
-			initialTheme: "dark",
-		});
+	test("accepts stored value when in themes list", () => {
+		expect(parseThemeCookie("theme=dark", { themes: ["light", "dark"] })).toBe("dark");
+	});
 
-		expect(nextCookieReads).toBe(0);
-		expect((element.props as { initialTheme?: string }).initialTheme).toBe("dark");
+	test("decodes URL-encoded cookie value", () => {
+		expect(parseThemeCookie("theme=high%2Dcontrast")).toBe("high-contrast");
+	});
+
+	test("ignores malformed URL-encoded cookie values", () => {
+		expect(parseThemeCookie("theme=%E0%A4%A", { defaultTheme: "dark" })).toBe("dark");
+	});
+
+	test("handles multiple cookies", () => {
+		expect(parseThemeCookie("other=value; theme=dark; another=foo")).toBe("dark");
+	});
+
+	test("handles storageKey with special regex characters", () => {
+		expect(parseThemeCookie("theme.v2=light", { storageKey: "theme.v2" })).toBe("light");
+	});
+
+	test("does not match partial cookie name", () => {
+		expect(parseThemeCookie("xtheme=dark", { defaultTheme: "light" })).toBe("light");
+	});
+
+	test("empty cookie value returns defaultTheme", () => {
+		expect(parseThemeCookie("theme=", { defaultTheme: "dark" })).toBe("dark");
 	});
 });
 
-describe("Extended Next ThemeProvider App Shell behavior", () => {
-	test("leaves cookie reads to the pre-hydration script", async () => {
-		nextCookieValue = "midnight";
-		const { ExtendedThemeProvider } = await import("../providers/extended-next-provider.js");
-		const element = ExtendedThemeProvider({
-			children: null,
-			storage: "cookie",
-			themes: ["paper", "midnight"],
-			systemThemeMap: { light: "paper", dark: "midnight" },
-		});
-
-		expect(nextCookieReads).toBe(0);
-		expect((element.props as { initialTheme?: string }).initialTheme).toBeUndefined();
-	});
-
-	test("preserves an explicit initialTheme without reading request data", async () => {
-		const { ExtendedThemeProvider } = await import("../providers/extended-next-provider.js");
-		const element = ExtendedThemeProvider({
-			children: null,
-			storage: "cookie",
-			themes: ["paper", "midnight"],
-			initialTheme: "midnight",
-			systemThemeMap: { light: "paper", dark: "midnight" },
-		});
-
-		expect(nextCookieReads).toBe(0);
-		expect((element.props as { initialTheme?: string }).initialTheme).toBe("midnight");
+describe("server helpers stay Next-free", () => {
+	test("get-theme.ts and server.ts do not import next/headers", () => {
+		expect(readFileSync(resolve(srcDir, "get-theme.ts"), "utf-8")).not.toContain(
+			"next/headers",
+		);
+		expect(readFileSync(resolve(srcDir, "server.ts"), "utf-8")).not.toContain("next/headers");
 	});
 });

--- a/packages/themes/src/__tests__/next-get-theme.test.ts
+++ b/packages/themes/src/__tests__/next-get-theme.test.ts
@@ -1,0 +1,127 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+let nextCookieValue: string | undefined;
+let nextCookieReads = 0;
+
+mock.module("next/headers", () => ({
+	cookies: async () => {
+		nextCookieReads += 1;
+		return {
+			get: (_key: string) =>
+				nextCookieValue === undefined
+					? undefined
+					: { name: "theme", value: nextCookieValue },
+		};
+	},
+}));
+
+const { getTheme } = await import("../next-get-theme.js");
+
+function makeRequest(cookieHeader: string): Request {
+	return new Request("https://example.com", {
+		headers: { cookie: cookieHeader },
+	});
+}
+
+beforeEach(() => {
+	nextCookieValue = undefined;
+	nextCookieReads = 0;
+});
+
+describe("getTheme - sync (Request) via /next wrapper", () => {
+	test("delegates to the Request helper without reading next/headers", () => {
+		expect(getTheme(makeRequest("theme=dark"))).toBe("dark");
+		expect(nextCookieReads).toBe(0);
+	});
+});
+
+describe("getTheme - async (no Request)", () => {
+	test("returns defaultTheme when the cookie is absent", async () => {
+		expect(await getTheme({ defaultTheme: "dark" })).toBe("dark");
+	});
+
+	test("returns 'system' as default when no options provided", async () => {
+		expect(await getTheme()).toBe("system");
+	});
+
+	test("returns a valid stored theme", async () => {
+		nextCookieValue = "dark";
+		expect(await getTheme({ themes: ["light", "dark"] })).toBe("dark");
+	});
+
+	test("accepts system when a themes allowlist is provided", async () => {
+		nextCookieValue = "system";
+		expect(await getTheme({ themes: ["light", "dark"] })).toBe("system");
+	});
+
+	test("returns defaultTheme for unknown, encoded, or malformed values outside the allowlist", async () => {
+		for (const stored of ["unknown", "high%2Dcontrast", "%E0%A4%A"]) {
+			nextCookieValue = stored;
+			expect(
+				await getTheme({
+					themes: ["light", "dark"],
+					defaultTheme: "light",
+				}),
+			).toBe("light");
+		}
+	});
+});
+
+describe("Next ThemeProvider App Shell behavior", () => {
+	test("leaves cookie reads to the pre-hydration script", async () => {
+		nextCookieValue = "dark";
+		const { ThemeProvider } = await import("../providers/next-provider.js");
+		const element = ThemeProvider({
+			children: null,
+			storage: "cookie",
+			themes: ["light", "dark"],
+		});
+
+		expect(nextCookieReads).toBe(0);
+		expect((element.props as { storage?: string }).storage).toBe("cookie");
+		expect((element.props as { initialTheme?: string }).initialTheme).toBeUndefined();
+	});
+
+	test("preserves an explicit initialTheme without reading request data", async () => {
+		const { ThemeProvider } = await import("../providers/next-provider.js");
+		const element = ThemeProvider({
+			children: null,
+			storage: "cookie",
+			themes: ["light", "dark"],
+			initialTheme: "dark",
+		});
+
+		expect(nextCookieReads).toBe(0);
+		expect((element.props as { initialTheme?: string }).initialTheme).toBe("dark");
+	});
+});
+
+describe("Extended Next ThemeProvider App Shell behavior", () => {
+	test("leaves cookie reads to the pre-hydration script", async () => {
+		nextCookieValue = "midnight";
+		const { ExtendedThemeProvider } = await import("../providers/extended-next-provider.js");
+		const element = ExtendedThemeProvider({
+			children: null,
+			storage: "cookie",
+			themes: ["paper", "midnight"],
+			systemThemeMap: { light: "paper", dark: "midnight" },
+		});
+
+		expect(nextCookieReads).toBe(0);
+		expect((element.props as { initialTheme?: string }).initialTheme).toBeUndefined();
+	});
+
+	test("preserves an explicit initialTheme without reading request data", async () => {
+		const { ExtendedThemeProvider } = await import("../providers/extended-next-provider.js");
+		const element = ExtendedThemeProvider({
+			children: null,
+			storage: "cookie",
+			themes: ["paper", "midnight"],
+			initialTheme: "midnight",
+			systemThemeMap: { light: "paper", dark: "midnight" },
+		});
+
+		expect(nextCookieReads).toBe(0);
+		expect((element.props as { initialTheme?: string }).initialTheme).toBe("midnight");
+	});
+});

--- a/packages/themes/src/__tests__/type-inference.tsx
+++ b/packages/themes/src/__tests__/type-inference.tsx
@@ -15,6 +15,7 @@ import {
 	type TypedThemedImageProps,
 } from "../index.js";
 import { type GetThemeOptions, getTheme } from "../next.js";
+import { getTheme as getServerTheme, parseThemeCookie } from "../server.js";
 import {
 	createThemes as createNextThemes,
 	type CreateNextThemesResult,
@@ -48,6 +49,26 @@ expectType<Promise<"light" | "dark" | "system">>(asyncTheme);
 
 const looseTheme = getTheme(request, { defaultTheme: "dark" });
 expectType<string>(looseTheme);
+
+const serverTheme = getServerTheme(request, {
+	themes: appThemes,
+	defaultTheme: "light",
+});
+expectType<AppTheme>(serverTheme);
+expectType<Equal<typeof serverTheme, AppTheme>>(true);
+
+const parsedTheme = parseThemeCookie("theme=dark", {
+	themes: appThemes,
+	defaultTheme: "light",
+});
+expectType<AppTheme>(parsedTheme);
+expectType<Equal<typeof parsedTheme, AppTheme>>(true);
+
+function unusedServerGetThemeArityCheck(): void {
+	// @ts-expect-error server getTheme requires a Request
+	getServerTheme();
+}
+expectType<() => void>(unusedServerGetThemeArityCheck);
 
 const invalidGetThemeOptions = {
 	themes: appThemes,

--- a/packages/themes/src/get-theme.ts
+++ b/packages/themes/src/get-theme.ts
@@ -33,39 +33,58 @@ function safeDecodeURIComponent(value: string): string | null {
 	}
 }
 
-function readFromCookieString(
-	cookieString: string,
-	storageKey: string,
-	defaultTheme: string,
-	themes: readonly string[] | undefined,
+/** Shared by cookie-header parsing and Next `cookies()`. Not part of the public `/server` API. */
+export function resolveStoredThemeValue(
+	stored: string | null | undefined,
+	options?: {
+		storageKey?: string | undefined;
+		defaultTheme?: string | undefined;
+		themes?: readonly string[] | undefined;
+	},
 ): string {
-	const re = new RegExp(
-		`(?:^|;\\s*)${storageKey.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}=([^;]*)`,
-	);
-	const match = cookieString.match(re);
-	const stored = match?.[1] != null ? safeDecodeURIComponent(match[1]) : null;
+	const defaultTheme = options?.defaultTheme ?? "system";
+	const themes = options?.themes;
 	if (!stored) return defaultTheme;
 	if (!isThemeSelection(stored, themes)) return defaultTheme;
 	return stored;
 }
 
+function parseThemeCookieRuntime(cookieHeader: string, options?: RuntimeGetThemeOptions): string {
+	const storageKey = options?.storageKey ?? "theme";
+	const re = new RegExp(
+		`(?:^|;\\s*)${storageKey.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}=([^;]*)`,
+	);
+	const match = cookieHeader.match(re);
+	const stored = match?.[1] != null ? safeDecodeURIComponent(match[1]) : null;
+	return resolveStoredThemeValue(stored, options);
+}
+
 /**
- * Reads the current theme from a cookie.
- *
- * Pass a `Request` object for synchronous use in middleware or edge functions.
- * Call without arguments for async use in Server Components (reads via `cookies()` from `next/headers`).
+ * Reads the current theme from a `Cookie` header string.
  *
  * @example
- * // Proxy
- * export function proxy(request: Request) {
+ * const theme = parseThemeCookie(request.headers.get("cookie") ?? "", { defaultTheme: "dark" });
+ */
+export function parseThemeCookie<
+	const Themes extends readonly [string, ...string[]],
+	const DefaultThemeValue extends ThemeSelection<ThemeName<Themes>> = "system",
+>(
+	cookieHeader: string,
+	options: GetThemeOptions<Themes> & { themes: Themes; defaultTheme?: DefaultThemeValue },
+): GetThemeResult<Themes, DefaultThemeValue>;
+export function parseThemeCookie(cookieHeader: string, options?: UntypedGetThemeOptions): string;
+export function parseThemeCookie(cookieHeader: string, options?: RuntimeGetThemeOptions): string {
+	return parseThemeCookieRuntime(cookieHeader, options);
+}
+
+/**
+ * Reads the current theme from a `Request` cookie header.
+ *
+ * @example
+ * export function loader({ request }: { request: Request }) {
  *   const theme = getTheme(request, { defaultTheme: "dark" });
- *   // use theme to set a header, rewrite, etc.
+ *   return { theme };
  * }
- *
- * @example
- * // Server Component / layout.tsx
- * const theme = await getTheme({ defaultTheme: "dark" });
- * return <html className={theme}>...</html>;
  */
 export function getTheme<
 	const Themes extends readonly [string, ...string[]],
@@ -75,37 +94,6 @@ export function getTheme<
 	options: GetThemeOptions<Themes> & { themes: Themes; defaultTheme?: DefaultThemeValue },
 ): GetThemeResult<Themes, DefaultThemeValue>;
 export function getTheme(request: Request, options?: UntypedGetThemeOptions): string;
-export function getTheme<
-	const Themes extends readonly [string, ...string[]],
-	const DefaultThemeValue extends ThemeSelection<ThemeName<Themes>> = "system",
->(
-	options: GetThemeOptions<Themes> & { themes: Themes; defaultTheme?: DefaultThemeValue },
-): Promise<GetThemeResult<Themes, DefaultThemeValue>>;
-export function getTheme(options?: UntypedGetThemeOptions): Promise<string>;
-export function getTheme(
-	requestOrOptions?: Request | RuntimeGetThemeOptions,
-	options?: RuntimeGetThemeOptions,
-): string | Promise<string> {
-	const isRequest = requestOrOptions instanceof Request;
-	const opts =
-		(isRequest ? options : (requestOrOptions as RuntimeGetThemeOptions | undefined)) ?? {};
-	const { storageKey = "theme", defaultTheme = "system", themes } = opts;
-
-	if (isRequest) {
-		const cookieHeader = requestOrOptions.headers.get("cookie") ?? "";
-		return readFromCookieString(cookieHeader, storageKey, defaultTheme, themes);
-	}
-
-	return (async () => {
-		try {
-			const { cookies } = await import("next/headers");
-			const cookieStore = await cookies();
-			const stored = cookieStore.get(storageKey)?.value;
-			if (!stored) return defaultTheme;
-			if (!isThemeSelection(stored, themes)) return defaultTheme;
-			return stored;
-		} catch {
-			return defaultTheme;
-		}
-	})();
+export function getTheme(request: Request, options?: RuntimeGetThemeOptions): string {
+	return parseThemeCookieRuntime(request.headers.get("cookie") ?? "", options);
 }

--- a/packages/themes/src/next-get-theme.ts
+++ b/packages/themes/src/next-get-theme.ts
@@ -1,0 +1,78 @@
+import { cookies } from "next/headers";
+import type { ThemeName, ThemeSelection } from "./core/types.js";
+import {
+	getTheme as getThemeFromRequest,
+	resolveStoredThemeValue,
+	type GetThemeOptions,
+	type GetThemeResult,
+} from "./get-theme.js";
+
+type UntypedGetThemeOptions = Omit<GetThemeOptions, "themes"> & {
+	themes?: undefined;
+};
+
+type RuntimeGetThemeOptions = {
+	storageKey?: string | undefined;
+	defaultTheme?: string | undefined;
+	themes?: readonly string[] | undefined;
+};
+
+const readThemeFromRequest = getThemeFromRequest as (
+	request: Request,
+	options?: RuntimeGetThemeOptions,
+) => string;
+
+/**
+ * Reads the current theme from a cookie.
+ *
+ * Pass a `Request` object for synchronous use in middleware or edge functions.
+ * Call without arguments for async use in Server Components (reads via `cookies()` from `next/headers`).
+ *
+ * @example
+ * // Proxy
+ * export function proxy(request: Request) {
+ *   const theme = getTheme(request, { defaultTheme: "dark" });
+ *   // use theme to set a header, rewrite, etc.
+ * }
+ *
+ * @example
+ * // Server Component / layout.tsx
+ * const theme = await getTheme({ defaultTheme: "dark" });
+ * return <html className={theme}>...</html>;
+ */
+export function getTheme<
+	const Themes extends readonly [string, ...string[]],
+	const DefaultThemeValue extends ThemeSelection<ThemeName<Themes>> = "system",
+>(
+	request: Request,
+	options: GetThemeOptions<Themes> & { themes: Themes; defaultTheme?: DefaultThemeValue },
+): GetThemeResult<Themes, DefaultThemeValue>;
+export function getTheme(request: Request, options?: UntypedGetThemeOptions): string;
+export function getTheme<
+	const Themes extends readonly [string, ...string[]],
+	const DefaultThemeValue extends ThemeSelection<ThemeName<Themes>> = "system",
+>(
+	options: GetThemeOptions<Themes> & { themes: Themes; defaultTheme?: DefaultThemeValue },
+): Promise<GetThemeResult<Themes, DefaultThemeValue>>;
+export function getTheme(options?: UntypedGetThemeOptions): Promise<string>;
+export function getTheme(
+	requestOrOptions?: Request | RuntimeGetThemeOptions,
+	options?: RuntimeGetThemeOptions,
+): string | Promise<string> {
+	if (requestOrOptions instanceof Request) {
+		return readThemeFromRequest(requestOrOptions, options);
+	}
+
+	const opts = requestOrOptions ?? {};
+	const { storageKey = "theme", defaultTheme = "system" } = opts;
+
+	return (async () => {
+		try {
+			const cookieStore = await cookies();
+			const stored = cookieStore.get(storageKey)?.value;
+			return resolveStoredThemeValue(stored, { ...opts, defaultTheme });
+		} catch {
+			return defaultTheme;
+		}
+	})();
+}

--- a/packages/themes/src/next.ts
+++ b/packages/themes/src/next.ts
@@ -20,5 +20,5 @@ export type {
 	TypedThemedImageProps,
 } from "./factory/create-themes.js";
 export type { GetThemeOptions, GetThemeResult } from "./get-theme.js";
-export { getTheme } from "./get-theme.js";
+export { getTheme } from "./next-get-theme.js";
 export { ThemeProvider } from "./providers/next-provider.js";

--- a/packages/themes/src/server.ts
+++ b/packages/themes/src/server.ts
@@ -1,0 +1,2 @@
+export type { GetThemeOptions, GetThemeResult } from "./get-theme.js";
+export { getTheme, parseThemeCookie } from "./get-theme.js";

--- a/packages/themes/test-d/public-api.tsx
+++ b/packages/themes/test-d/public-api.tsx
@@ -30,6 +30,7 @@ import type {
 	ThemeProviderProps,
 } from "@wrksz/themes";
 import { getTheme, ThemeProvider as NextThemeProvider } from "@wrksz/themes/next";
+import { getTheme as getServerTheme, parseThemeCookie } from "@wrksz/themes/server";
 import {
 	createNextThemes,
 	createThemes as createNextCreateThemes,
@@ -102,10 +103,22 @@ const syncTheme = getTheme(new Request("https://example.com"), {
 	defaultTheme: "light",
 });
 const checkedTheme: AppTheme = syncTheme;
+const serverTheme = getServerTheme(new Request("https://example.com"), {
+	themes,
+	defaultTheme: "light",
+});
+const checkedServerTheme: AppTheme = serverTheme;
+const parsedTheme = parseThemeCookie("theme=dark", {
+	themes,
+	defaultTheme: "light",
+});
+const checkedParsedTheme: AppTheme = parsedTheme;
 const nextThemeScript = nextConfigured.ThemeScript();
 const nextRoot = <nextAlias.NextThemeProvider>{nextThemeScript}</nextAlias.NextThemeProvider>;
 
 export {
+	checkedParsedTheme,
+	checkedServerTheme,
 	checkedTheme,
 	ClientThemeProvider,
 	ClientThemeProviderSubpath,


### PR DESCRIPTION
## Summary
- Add `@wrksz/themes/server` with Request-only `getTheme` and `parseThemeCookie`, so Remix/TanStack/Vite can SSR `<html className={theme}>` without bundling `next/headers`.
- Keep `@wrksz/themes/next` `getTheme` as a thin wrapper: Request delegates to the server helper; `await getTheme()` still reads `cookies()` from `next/headers`.
- Document the split on the getTheme API page and the framework-agnostic example, and keep package exports / Bunup entries / smoke-exports in lockstep.

## Test plan
- [x] `bun run --cwd packages/themes test` (Request + parseThemeCookie cases, Next wrapper `cookies()` mock, no `next/headers` in `get-theme.ts`/`server.ts`)
- [x] `bun run --cwd packages/themes type-check`
- [x] `bun run --cwd packages/themes build && bun packages/themes/scripts/smoke-exports.ts` (`dist/server.js` has no `next/headers`)
- [x] `pnpm verify`