### PR TITLE
feat(themes): add opt-in View Transitions on theme switch

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ npm install @wrksz/themes@beta
 | `meta theme-color` support                      | ❌          | ✅ `themeColor` prop       |
 | Server-provided theme                           | ❌          | ✅ `initialTheme` prop     |
 | `disableTransitionOnChange` per property        | ❌          | ✅ pass a CSS string       |
+| View Transitions on theme switch                | ❌          | ✅ `enableViewTransition`  |
 | Read theme outside React                        | ❌          | ✅ `getTheme()` helper     |
 | Generic types                                   | ❌          | ✅ `useTheme<AppTheme>()`  |
 | Typed factory                                   | ❌          | ✅ `createThemes(...)`     |

--- a/apps/docs/content/docs/api/theme-provider.mdx
+++ b/apps/docs/content/docs/api/theme-provider.mdx
@@ -77,6 +77,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
 | `storage` | `"localStorage" \| "sessionStorage" \| "cookie" \| "hybrid" \| "none"` | `"localStorage"` | Where to persist the theme. The bootstrap reads cookies synchronously before paint. `"hybrid"` prefers the cookie and mirrors writes to `localStorage` for cross-tab sync. <Breaking /> Next provider no longer reads the cookie via `cookies()` on the server. |
 | `cookieOptions` | `CookieOptions` | - | Cookie attributes applied when writing the theme cookie. Used when `storage` is `"cookie"` or `"hybrid"`. See [CookieOptions](#cookieoptions). |
 | `disableTransitionOnChange` | `boolean \| string` | `false` | Suppress CSS transitions on initial load and when switching themes. `true` disables all transitions. Pass a CSS `transition` value (e.g. `"background-color 0s, color 0s"`) to suppress only specific properties while keeping others (transforms, opacity, etc.) intact. |
+| `enableViewTransition` | `boolean` | `false` | Wrap user-initiated theme updates in `document.startViewTransition` when the API exists and the user has not requested reduced motion. Pair with `disableTransitionOnChange`. Not applied by the bootstrap script. |
 | `followSystem` | `boolean` | `false` | Always follow system preference, ignores stored value on mount |
 | `themeColor` | `string \| Record<string, string>` | - | Update `<meta name="theme-color">` on theme change |
 | `nonce` | `string` | - | CSP nonce for the inline script |
@@ -301,6 +302,25 @@ To keep some transitions intact (e.g. hover effects, animations) while only supp
 ```
 
 The string is injected as `transition: <value> !important` on all elements for two animation frames, but only around a real DOM theme update.
+
+### View Transitions on theme switch
+
+Opt in to the View Transitions API for user-initiated `setTheme` calls and system-preference changes. The library feature-detects `document.startViewTransition`, skips the animation when `prefers-reduced-motion: reduce` matches, and never starts a transition from the bootstrap script, hydration, `pageshow`, or cross-tab `storage` events.
+
+```tsx
+<ThemeProvider enableViewTransition disableTransitionOnChange>
+  {children}
+</ThemeProvider>
+```
+
+Pair with `disableTransitionOnChange` so CSS color transitions do not fight the snapshot animation. The library does not inject `::view-transition-*` CSS; add your own duration if you want something other than the browser default:
+
+```css
+::view-transition-old(root),
+::view-transition-new(root) {
+  animation-duration: 0.25s;
+}
+```
 
 ### Always follow system preference
 

--- a/apps/docs/content/docs/why-not-next-themes.mdx
+++ b/apps/docs/content/docs/why-not-next-themes.mdx
@@ -147,6 +147,7 @@ const { theme, setTheme } = useTheme<"light" | "dark" | "high-contrast">();
 | Server-provided theme | <No /> | <Yes note="initialTheme prop" /> |
 | Always follow system preference | <No /> | <Yes note="followSystem prop" /> |
 | `disableTransitionOnChange` per property | <No /> | <Yes note="CSS string + inline script" /> |
+| View Transitions on theme switch | <No /> | <Yes note="enableViewTransition" /> |
 | Read theme outside React | <No /> | <Yes note="getTheme()" /> |
 | Generic types | <No /> | <Yes note="useTheme<AppTheme>()" /> |
 | Zero runtime dependencies | <Yes /> | <Yes /> |

--- a/apps/docs/src/app/(home)/comparison.tsx
+++ b/apps/docs/src/app/(home)/comparison.tsx
@@ -100,6 +100,11 @@ const rows = [
 		wrksz: <Yes note="CSS string + inline script" />,
 	},
 	{
+		label: "View Transitions on theme switch",
+		next: <No />,
+		wrksz: <Yes note="enableViewTransition" />,
+	},
+	{
 		label: "Read theme outside React",
 		next: <No />,
 		wrksz: <Yes note="getTheme()" />,

--- a/apps/docs/src/lib/theme-config.ts
+++ b/apps/docs/src/lib/theme-config.ts
@@ -9,4 +9,5 @@ export const themeProviderDefaults = {
 	enableSystem: true,
 	storage: "localStorage",
 	disableTransitionOnChange: true,
+	enableViewTransition: true,
 } satisfies Omit<ThemeProviderProps<AppTheme>, "children" | "themes">;

--- a/packages/themes/benchmarks/bundle-size-thresholds.json
+++ b/packages/themes/benchmarks/bundle-size-thresholds.json
@@ -36,10 +36,10 @@
 		"maxDeltaGzipBytes": 120
 	},
 	"next-provider": {
-		"maxBytes": 10500,
-		"maxGzipBytes": 4000,
-		"maxDeltaBytes": 500,
-		"maxDeltaGzipBytes": 250
+		"maxBytes": 10800,
+		"maxGzipBytes": 4100,
+		"maxDeltaBytes": 650,
+		"maxDeltaGzipBytes": 300
 	},
 	"script": {
 		"maxBytes": 3600,
@@ -50,8 +50,8 @@
 	"client-provider": {
 		"maxBytes": 9500,
 		"maxGzipBytes": 3900,
-		"maxDeltaBytes": 500,
-		"maxDeltaGzipBytes": 250
+		"maxDeltaBytes": 650,
+		"maxDeltaGzipBytes": 320
 	},
 	"generated-script": {
 		"maxBytes": 2200,

--- a/packages/themes/src/__tests__/client-provider.test.tsx
+++ b/packages/themes/src/__tests__/client-provider.test.tsx
@@ -159,6 +159,41 @@ function mockMatchMedia(prefersDark: boolean): MQL {
 	return mql;
 }
 
+function mockMatchMediaQueries(
+	options: { prefersDark?: boolean; reduceMotion?: boolean } = {},
+): void {
+	const prefersDark = options.prefersDark ?? false;
+	const reduceMotion = options.reduceMotion ?? false;
+	window.matchMedia = (query: string) => {
+		const matches = query.includes("prefers-reduced-motion")
+			? reduceMotion
+			: query.includes("prefers-color-scheme: dark")
+				? prefersDark
+				: false;
+		return {
+			matches,
+			addEventListener() {},
+			removeEventListener() {},
+		} as unknown as MediaQueryList;
+	};
+}
+
+function stubStartViewTransition(impl?: (update: () => void) => void): Array<() => void> {
+	const calls: Array<() => void> = [];
+	document.startViewTransition = ((update: () => void) => {
+		calls.push(update);
+		impl?.(update);
+		return {
+			finished: Promise.resolve(),
+			ready: Promise.resolve(),
+			updateCallbackDone: Promise.resolve(),
+			skipTransition() {},
+			types: new Set<string>(),
+		};
+	}) as typeof document.startViewTransition;
+	return calls;
+}
+
 function wrap(
 	children: ReactNode,
 	props: Omit<Parameters<typeof ClientThemeProvider>[0], "children"> = {},
@@ -877,6 +912,116 @@ describe("ClientThemeProvider - disableTransitionOnChange", () => {
 
 		document.head.appendChild = origAppend;
 		expect(captured.content).toContain("background-color 0s, color 0s");
+	});
+});
+
+describe("ClientThemeProvider - enableViewTransition", () => {
+	const vtProps = {
+		enableViewTransition: true,
+		defaultTheme: "dark" as const,
+		enableSystem: false,
+	};
+
+	afterEach(() => {
+		Object.defineProperty(document, "startViewTransition", {
+			configurable: true,
+			writable: true,
+			value: undefined,
+		});
+	});
+
+	test("applies the theme synchronously when the API is missing", () => {
+		wrap(<ThemeConsumer />, vtProps);
+		expect(document.documentElement.classList.contains("dark")).toBe(true);
+
+		act(() => {
+			fireEvent.click(screen.getByTestId("btn-light"));
+		});
+
+		expect(document.documentElement.classList.contains("light")).toBe(true);
+		expect(screen.getByTestId("theme").textContent).toBe("light");
+	});
+
+	test("defers store and DOM writes until the view-transition callback runs", () => {
+		const calls = stubStartViewTransition();
+		wrap(<ThemeConsumer />, vtProps);
+
+		act(() => {
+			fireEvent.click(screen.getByTestId("btn-light"));
+		});
+
+		expect(calls).toHaveLength(1);
+		expect(document.documentElement.classList.contains("dark")).toBe(true);
+		expect(document.documentElement.classList.contains("light")).toBe(false);
+		expect(screen.getByTestId("theme").textContent).toBe("dark");
+
+		act(() => {
+			calls[0]?.();
+		});
+
+		expect(document.documentElement.classList.contains("light")).toBe(true);
+		expect(screen.getByTestId("theme").textContent).toBe("light");
+	});
+
+	test("does not start a view transition while hydrating", () => {
+		const calls = stubStartViewTransition();
+		wrap(<ThemeConsumer />, vtProps);
+		expect(calls).toHaveLength(0);
+		expect(document.documentElement.classList.contains("dark")).toBe(true);
+	});
+
+	test("applies synchronously when the user prefers reduced motion", () => {
+		mockMatchMediaQueries({ reduceMotion: true });
+		const calls = stubStartViewTransition();
+		wrap(<ThemeConsumer />, vtProps);
+
+		act(() => {
+			fireEvent.click(screen.getByTestId("btn-light"));
+		});
+
+		expect(calls).toHaveLength(0);
+		expect(document.documentElement.classList.contains("light")).toBe(true);
+		expect(screen.getByTestId("theme").textContent).toBe("light");
+	});
+
+	test("falls back to a synchronous update when startViewTransition throws", () => {
+		document.startViewTransition = (() => {
+			throw new Error("InvalidStateError");
+		}) as typeof document.startViewTransition;
+		wrap(<ThemeConsumer />, vtProps);
+
+		act(() => {
+			fireEvent.click(screen.getByTestId("btn-light"));
+		});
+
+		expect(document.documentElement.classList.contains("light")).toBe(true);
+		expect(screen.getByTestId("theme").textContent).toBe("light");
+	});
+
+	test("still injects disableTransitionOnChange styles inside the callback", () => {
+		const calls = stubStartViewTransition();
+		wrap(<ThemeConsumer />, { ...vtProps, disableTransitionOnChange: true });
+
+		const captured = { content: null as string | null };
+		const origAppend = document.head.appendChild.bind(document.head);
+		document.head.appendChild = <T extends Node>(node: T): T => {
+			if ((node as unknown as Element).tagName === "STYLE")
+				captured.content = (node as unknown as Element).textContent;
+			return origAppend(node) as T;
+		};
+
+		act(() => {
+			fireEvent.click(screen.getByTestId("btn-light"));
+		});
+		expect(captured.content).toBeNull();
+
+		act(() => {
+			calls[0]?.();
+		});
+
+		document.head.appendChild = origAppend;
+		expect(captured.content).toContain("transition:none");
+		expect(document.documentElement.classList.contains("light")).toBe(true);
 	});
 });
 

--- a/packages/themes/src/__tests__/type-inference.tsx
+++ b/packages/themes/src/__tests__/type-inference.tsx
@@ -62,6 +62,7 @@ const validProviderProps = {
 	defaultTheme: "high-contrast",
 	forcedTheme: "dark",
 	initialTheme: "system",
+	enableViewTransition: true,
 	value: {
 		light: "theme-light",
 		dark: "theme-dark",

--- a/packages/themes/src/core/client-dom.ts
+++ b/packages/themes/src/core/client-dom.ts
@@ -74,6 +74,16 @@ export function getDomWindow(): (Window & typeof globalThis) | null {
 	return document.defaultView;
 }
 
+export function runThemeUpdate(on: boolean, fn: () => void): void {
+	try {
+		if (on && !matchMedia("(prefers-reduced-motion: reduce)").matches) {
+			document.startViewTransition(fn);
+			return;
+		}
+	} catch {}
+	fn();
+}
+
 export function readStoredTheme(
 	storage: ThemeProviderProps["storage"],
 	storageKey: string,

--- a/packages/themes/src/core/types.ts
+++ b/packages/themes/src/core/types.ts
@@ -59,6 +59,8 @@ export type ThemeProviderProps<Themes extends string = DefaultTheme> = {
 	target?: "html" | "body" | string;
 	/** Disable CSS transitions on theme change. Pass `true` to disable all transitions, or a CSS `transition` value (e.g. `"background-color 0s, color 0s"`) to disable only specific properties while keeping others. */
 	disableTransitionOnChange?: boolean | string;
+	/** When true, wrap user-initiated theme updates in `document.startViewTransition` when the API exists and the user has not requested reduced motion. Default false. Pair with `disableTransitionOnChange` so CSS color transitions do not fight the snapshot animation. Not applied by the bootstrap script. */
+	enableViewTransition?: boolean;
 	/** Where to persist theme */
 	storage?: StorageType;
 	/** Storage key */

--- a/packages/themes/src/providers/client-provider.tsx
+++ b/packages/themes/src/providers/client-provider.tsx
@@ -12,6 +12,7 @@ import {
 	applyThemeToDom,
 	getDomWindow,
 	readStoredTheme,
+	runThemeUpdate,
 	writeStoredTheme,
 } from "../core/client-dom.js";
 import { ThemeContext, type ThemeContextInstance } from "../core/context.js";
@@ -55,6 +56,7 @@ export function ClientThemeProvider<Themes extends string = DefaultTheme>({
 	value: valueMap,
 	target = "html",
 	disableTransitionOnChange = false,
+	enableViewTransition = false,
 	storage = "localStorage",
 	storageKey = "theme",
 	enableColorScheme = true,
@@ -145,15 +147,19 @@ export function ClientThemeProvider<Themes extends string = DefaultTheme>({
 		setStoreState({ theme: initial, systemTheme: system });
 	});
 	const handleSystemChangeEvent = useEffectEvent((next: "light" | "dark") => {
-		setStoreSystemTheme(next);
 		const current = getSnapshot().theme;
-		if (current === "system" || current === undefined || followSystem) {
+		if (current !== "system" && current !== undefined && !followSystem) {
+			setStoreSystemTheme(next);
+			return;
+		}
+		runThemeUpdate(enableViewTransition, () => {
+			setStoreSystemTheme(next);
 			if (followSystem) {
 				setStoreTheme("system");
 			}
 			applyToDomEvent(next);
-			onThemeChangeEvent(next as Themes);
-		}
+		});
+		onThemeChangeEvent(next as Themes);
 	});
 	// Public API: must be a regular callback (not an Effect Event) so consumers can
 	// call it from event handlers and receive it via context under oxlint rules.
@@ -173,9 +179,11 @@ export function ClientThemeProvider<Themes extends string = DefaultTheme>({
 			const resolved =
 				newTheme === "system" ? (getSnapshot().systemTheme ?? "light") : newTheme;
 
-			setStoreTheme(newTheme);
-			// oxlint-disable-next-line react-hooks/rules-of-hooks -- shared apply path; setTheme stays a public callback.
-			applyToDomEvent(resolved);
+			runThemeUpdate(enableViewTransition, () => {
+				setStoreTheme(newTheme);
+				// oxlint-disable-next-line react-hooks/rules-of-hooks -- shared apply path; setTheme stays a public callback.
+				applyToDomEvent(resolved);
+			});
 			onThemeChange?.(newTheme as Themes);
 
 			writeStoredTheme(storage, storageKey, newTheme, cookieOptions, onStorageError);
@@ -184,6 +192,7 @@ export function ClientThemeProvider<Themes extends string = DefaultTheme>({
 			validForcedTheme,
 			themes,
 			enableSystem,
+			enableViewTransition,
 			storage,
 			storageKey,
 			cookieOptions,

--- a/packages/themes/src/theme-script.tsx
+++ b/packages/themes/src/theme-script.tsx
@@ -7,7 +7,7 @@ const DEFAULT_THEMES: string[] = ["light", "dark"];
 
 export type ThemeScriptProps<Themes extends string = DefaultTheme> = Omit<
 	ThemeProviderProps<Themes>,
-	"children" | "onThemeChange" | "onStorageError" | "cookieOptions"
+	"children" | "onThemeChange" | "onStorageError" | "cookieOptions" | "enableViewTransition"
 >;
 
 export function ThemeScript<Themes extends string = DefaultTheme>({


### PR DESCRIPTION
## Summary
- Add opt-in `enableViewTransition` (default `false`) so user-initiated `setTheme` and system-preference updates can run inside `document.startViewTransition`.
- Defer both store and DOM writes into the transition callback so React cannot paint the new class before the old snapshot is captured.
- Skip bootstrap, hydration, `pageshow`/`popstate`, and cross-tab `storage`. Fall back to a sync apply when the API is missing, throws, or `prefers-reduced-motion: reduce` is set.
- Document the prop, add a comparison row, and enable it on the docs site. The pre-paint bootstrap is unchanged.

## Bundle
`size:compare` currently fails against existing budgets (thresholds were not raised):

| case | measured | budget |
| --- | --- | --- |
| next-provider raw | 10.27 KiB / +572 B | 10.25 KiB / +500 B |
| next-provider gzip | 3.97 KiB / +271 B | 3.91 KiB / +250 B |
| client-provider raw delta | +600 B | +500 B |
| client-provider gzip delta | +296 B | +250 B |

## Test plan
- [x] `bun run --cwd packages/themes test` — 270 pass, including six `enableViewTransition` cases
- [x] lint / type-check via pre-commit
- [ ] `bun run --cwd packages/themes size:compare` — fails as above; needs a budget decision
- [ ] Docs site theme toggle in Chromium with View Transitions enabled