### PR TITLE
fix: seed useTheme snapshots from initialTheme and forcedTheme

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ const theme = getTheme(request, {
 
 ### `useThemeValue`
 
-Returns the value from a map matching the current resolved theme. Returns `undefined` before the theme resolves on the client.
+Returns the value from a map matching the current resolved theme. Returns `undefined` while `resolvedTheme` is unknown.
 
 ```tsx
 "use client";

--- a/apps/docs/content/docs/api/theme-provider.mdx
+++ b/apps/docs/content/docs/api/theme-provider.mdx
@@ -67,7 +67,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
 | `themes` | `readonly string[]` | `["light", "dark"]` | Available themes. Use `as const` to preserve custom theme unions in TypeScript |
 | `defaultTheme` | `string` | `"system"` | Theme used when no preference is stored |
 | `forcedTheme` | `string` | - | Force a specific theme, ignoring user preference. <Breaking /> Does not write to storage on init. |
-| `initialTheme` | `string` | - | Server-provided theme that overrides storage on mount. User can still call `setTheme` to change it. <Breaking /> Mount init is sticky: later prop changes to `storageKey` / `initialTheme` do not re-run initialization (`forcedTheme` still updates via overlay). |
+| `initialTheme` | `string` | - | Server-provided theme that seeds the store snapshot and overrides storage on mount. User can still call `setTheme` to change it. A concrete value (not `"system"`) is available to `useTheme` during SSR; `"system"` does not yield `resolvedTheme` until mount. <Breaking /> Mount init is sticky: later prop changes to `storageKey` / `initialTheme` do not re-run initialization (`forcedTheme` still updates via overlay). |
 | `enableSystem` | `boolean` | `true` | Detect system preference via `prefers-color-scheme` |
 | `enableColorScheme` | `boolean` | `true` | Set native `color-scheme` CSS property |
 | `attribute` | `"class" \| "data-*" \| ("class" \| "data-*")[]` | `"class"` | HTML attribute(s) to set on the target element |
@@ -152,7 +152,7 @@ Map a theme to multiple CSS classes using a space-separated value:
 
 ### Server-provided theme
 
-Use `initialTheme` to initialize from a server-side source (database, session, cookie) on every mount:
+Use `initialTheme` to initialize from a server-side source (database, session, cookie) on every mount. A concrete value also seeds `useTheme` during SSR:
 
 ```tsx title="app/layout.tsx"
 export default async function RootLayout({ children }) {

--- a/apps/docs/content/docs/api/themed-image.mdx
+++ b/apps/docs/content/docs/api/themed-image.mdx
@@ -3,7 +3,7 @@ title: ThemedImage
 description: Component that displays the correct image for the current theme.
 ---
 
-`ThemedImage` renders a different image depending on the current resolved theme. Before the theme resolves on the client, it shows a transparent 1x1 placeholder to avoid hydration mismatch.
+`ThemedImage` renders a different image depending on the current resolved theme. While `resolvedTheme` is unknown, it shows a transparent 1x1 placeholder to avoid hydration mismatch. The placeholder is skipped when `initialTheme` or `forcedTheme` is a concrete theme (not `"system"`).
 
 ```tsx
 import { ThemedImage } from "@wrksz/themes/client";
@@ -22,7 +22,7 @@ import { ThemedImage } from "@wrksz/themes/client";
 |------|------|---------|-------------|
 | `src` | `Record<string, string>` | **required** | Map of theme name to image source |
 | `alt` | `string` | **required** | Alt text |
-| `fallback` | `string` | transparent 1x1 GIF | Shown before the theme resolves |
+| `fallback` | `string` | transparent 1x1 GIF | Shown while `resolvedTheme` is unknown |
 | `...rest` | `ImgHTMLAttributes` | - | All other `<img>` attributes |
 
 ## Examples
@@ -44,7 +44,7 @@ import { ThemedImage } from "@wrksz/themes/client";
 
 ### Custom fallback
 
-By default the placeholder is a transparent 1x1 GIF, so the image space is empty until the theme resolves. You can provide a custom fallback - for example a low-quality placeholder or a neutral image:
+By default the placeholder is a transparent 1x1 GIF, so the image space is empty while `resolvedTheme` is unknown. You can provide a custom fallback - for example a low-quality placeholder or a neutral image:
 
 ```tsx
 <ThemedImage

--- a/apps/docs/content/docs/api/use-theme-value.mdx
+++ b/apps/docs/content/docs/api/use-theme-value.mdx
@@ -3,7 +3,7 @@ title: useThemeValue
 description: Hook that returns a value from a map keyed by the current resolved theme.
 ---
 
-`useThemeValue` returns the value from a map that matches the current resolved theme. Returns `undefined` before the theme resolves on the client.
+`useThemeValue` returns the value from a map that matches the current resolved theme. Returns `undefined` while `resolvedTheme` is unknown (browser storage, or `initialTheme`/`forcedTheme` set to `"system"`).
 
 ```tsx
 "use client";
@@ -54,7 +54,7 @@ const icon = useThemeValue({
 
 ### next/image
 
-`useThemeValue` returns `undefined` before the theme resolves, which `next/image` does not accept as `src`. Use a fallback with `??`:
+`useThemeValue` returns `undefined` while `resolvedTheme` is unknown, which `next/image` does not accept as `src`. Use a fallback with `??`:
 
 ```tsx
 "use client";

--- a/apps/docs/content/docs/api/use-theme.mdx
+++ b/apps/docs/content/docs/api/use-theme.mdx
@@ -29,7 +29,7 @@ export function ThemeToggle() {
 | Property | Type | Description |
 |----------|------|-------------|
 | `theme` | `string \| undefined` | Current theme - may be `"system"` |
-| `resolvedTheme` | `string \| undefined` | Actual applied theme - never `"system"`. `undefined` before hydration |
+| `resolvedTheme` | `string \| undefined` | Actual applied theme - never `"system"`. `undefined` until the resolved theme is known |
 | `systemTheme` | `"light" \| "dark" \| undefined` | Current system preference |
 | `forcedTheme` | `string \| undefined` | Forced theme if set via `forcedTheme` prop |
 | `themes` | `string[]` | Available themes |
@@ -62,7 +62,11 @@ resolvedTheme // "dark"
 
 ## Hydration
 
-Both `theme` and `resolvedTheme` are `undefined` on the server and during the first client render to avoid hydration mismatch. Use `resolvedTheme` with a fallback or conditional rendering:
+When the theme comes from browser storage, `theme` and `resolvedTheme` are `undefined` on the server and during the first client render so the snapshots match.
+
+When `initialTheme` or `forcedTheme` is a concrete theme (not `"system"`), both values are available during SSR and the first client render. `"system"` still leaves `resolvedTheme` unknown until `matchMedia` runs on mount.
+
+Use `resolvedTheme` with a fallback or conditional rendering when it may still be unknown:
 
 ```tsx
 const { resolvedTheme } = useTheme();
@@ -71,7 +75,7 @@ const { resolvedTheme } = useTheme();
 if (!resolvedTheme) return null;
 ```
 
-For images, use [`ThemedImage`](/docs/api/themed-image) or [`useThemeValue`](/docs/api/use-theme-value) which handle this automatically.
+For images, use [`ThemedImage`](/docs/api/themed-image) or [`useThemeValue`](/docs/api/use-theme-value) which handle the unresolved state automatically.
 
 ## `setTheme` with a function
 

--- a/apps/docs/content/docs/examples/hydration-and-consent.mdx
+++ b/apps/docs/content/docs/examples/hydration-and-consent.mdx
@@ -5,7 +5,9 @@ description: Render theme controls safely and choose when preferences may be per
 
 ## Hydration-safe controls
 
-Theme state is unknown in server HTML when it comes from browser storage. Use `useHydrated()` instead of setting mount state inside an effect:
+Theme state is unknown in server HTML when it comes from browser storage. Use `useHydrated()` instead of setting mount state inside an effect.
+
+When `initialTheme` or `forcedTheme` is a concrete theme (not `"system"`), `useTheme().theme` is already known in server HTML, so the real selected value can render without a hydration placeholder. `"system"` still cannot resolve to light or dark without `matchMedia`.
 
 ```tsx
 "use client";

--- a/apps/docs/content/docs/examples/server-theme.mdx
+++ b/apps/docs/content/docs/examples/server-theme.mdx
@@ -68,7 +68,7 @@ export default async function RootLayout({ children }) {
 }
 ```
 
-`initialTheme` also writes to storage on mount, so `setTheme` and cross-tab sync continue to work normally.
+`initialTheme` also writes to storage on mount, so `setTheme` and cross-tab sync continue to work normally. A concrete `initialTheme` (not `"system"`) seeds `useTheme`, `useThemeValue`, and `ThemedImage` during SSR, not only the `<html>` class.
 
 ## Priority
 

--- a/apps/docs/content/docs/migration.mdx
+++ b/apps/docs/content/docs/migration.mdx
@@ -62,7 +62,7 @@ That's it for most apps.
 ### Migration path
 
 - For zero-flash without request-time APIs, keep `storage="cookie"` or `"hybrid"`. The pre-paint bootstrap still reads the cookie before hydration.
-- If server-rendered markup must know the theme, do this explicitly:
+- If server-rendered markup must know the theme, do this explicitly. Passing `initialTheme` from [`getTheme`](/docs/api/get-theme) also seeds React theme state (`useTheme`, `useThemeValue`, `ThemedImage`), not only `<html className>`:
 
 ```tsx title="app/layout.tsx"
 import { ThemeProvider, getTheme } from "@wrksz/themes/next";

--- a/packages/themes/src/__tests__/client-next-provider.test.tsx
+++ b/packages/themes/src/__tests__/client-next-provider.test.tsx
@@ -2,6 +2,10 @@ import { afterEach, describe, expect, mock, test } from "bun:test";
 import "./setup.js";
 import { cleanup, render } from "@testing-library/react";
 import { isValidElement, type ReactElement, type ReactNode } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { ThemedImage } from "../components/themed-image.js";
+import { useTheme } from "../core/context.js";
+import { useThemeValue } from "../hooks/use-theme-value.js";
 
 const insertedHtmlCallbacks: Array<() => ReactNode> = [];
 
@@ -20,6 +24,25 @@ type ScriptElement = ReactElement<{
 	nonce?: string;
 	suppressHydrationWarning?: boolean;
 }>;
+
+function ThemeConsumer() {
+	const { theme, resolvedTheme } = useTheme();
+	return (
+		<div>
+			<span data-testid="theme">{theme ?? "-"}</span>
+			<span data-testid="resolved">{resolvedTheme ?? "-"}</span>
+		</div>
+	);
+}
+
+function ValueReader({
+	values,
+}: {
+	values: Partial<Record<"light" | "dark" | "system" | "default", string>>;
+}) {
+	const value = useThemeValue(values);
+	return <span data-testid="value">{value ?? "-"}</span>;
+}
 
 afterEach(() => {
 	cleanup();
@@ -153,5 +176,123 @@ describe("ExtendedClientNextThemeProvider", () => {
 
 		const script = insertedHtmlCallbacks[0]?.() as ScriptElement;
 		expect(script.props.dangerouslySetInnerHTML?.__html).toContain('"paper",false');
+	});
+});
+
+describe("ClientNextThemeProvider - SSR snapshots", () => {
+	test("seeds theme and resolvedTheme from initialTheme", () => {
+		const html = renderToStaticMarkup(
+			<ClientNextThemeProvider storage="none" initialTheme="dark">
+				<ThemeConsumer />
+			</ClientNextThemeProvider>,
+		);
+		expect(html).toContain('data-testid="theme">dark</span>');
+		expect(html).toContain('data-testid="resolved">dark</span>');
+	});
+
+	test("leaves theme unknown when neither initialTheme nor forcedTheme is set", () => {
+		const html = renderToStaticMarkup(
+			<ClientNextThemeProvider storage="none">
+				<ThemeConsumer />
+			</ClientNextThemeProvider>,
+		);
+		expect(html).toContain('data-testid="theme">-</span>');
+		expect(html).toContain('data-testid="resolved">-</span>');
+	});
+
+	test("seeds theme and resolvedTheme from forcedTheme", () => {
+		const html = renderToStaticMarkup(
+			<ClientNextThemeProvider storage="none" forcedTheme="dark">
+				<ThemeConsumer />
+			</ClientNextThemeProvider>,
+		);
+		expect(html).toContain('data-testid="theme">dark</span>');
+		expect(html).toContain('data-testid="resolved">dark</span>');
+	});
+
+	test("forcedTheme wins over initialTheme", () => {
+		const html = renderToStaticMarkup(
+			<ClientNextThemeProvider storage="none" forcedTheme="dark" initialTheme="light">
+				<ThemeConsumer />
+			</ClientNextThemeProvider>,
+		);
+		expect(html).toContain('data-testid="theme">dark</span>');
+		expect(html).toContain('data-testid="resolved">dark</span>');
+	});
+
+	test("initialTheme=system reports theme but not resolvedTheme", () => {
+		const html = renderToStaticMarkup(
+			<ClientNextThemeProvider storage="none" initialTheme="system">
+				<ThemeConsumer />
+			</ClientNextThemeProvider>,
+		);
+		expect(html).toContain('data-testid="theme">system</span>');
+		expect(html).toContain('data-testid="resolved">-</span>');
+	});
+
+	test("ignores initialTheme that is not in the themes list", () => {
+		const html = renderToStaticMarkup(
+			<ClientNextThemeProvider storage="none" initialTheme={"invalid" as "light"}>
+				<ThemeConsumer />
+			</ClientNextThemeProvider>,
+		);
+		expect(html).toContain('data-testid="theme">-</span>');
+		expect(html).toContain('data-testid="resolved">-</span>');
+	});
+
+	test("ThemedImage uses the seeded theme source", () => {
+		const html = renderToStaticMarkup(
+			<ClientNextThemeProvider storage="none" initialTheme="dark">
+				<ThemedImage src={{ light: "/light.png", dark: "/dark.png" }} alt="Theme preview" />
+			</ClientNextThemeProvider>,
+		);
+		expect(html).toContain('src="/dark.png"');
+		expect(html).not.toContain("data:image/gif");
+	});
+
+	test("ThemedImage keeps the placeholder when initialTheme is system", () => {
+		const html = renderToStaticMarkup(
+			<ClientNextThemeProvider storage="none" initialTheme="system">
+				<ThemedImage src={{ light: "/light.png", dark: "/dark.png" }} alt="Theme preview" />
+			</ClientNextThemeProvider>,
+		);
+		expect(html).toContain("data:image/gif");
+		expect(html).not.toContain("/dark.png");
+		expect(html).not.toContain("/light.png");
+	});
+
+	test("useThemeValue returns the seeded resolved value", () => {
+		const html = renderToStaticMarkup(
+			<ClientNextThemeProvider storage="none" initialTheme="dark">
+				<ValueReader values={{ light: "Light", dark: "Dark" }} />
+			</ClientNextThemeProvider>,
+		);
+		expect(html).toContain('data-testid="value">Dark</span>');
+	});
+});
+
+describe("ExtendedClientNextThemeProvider - SSR snapshots", () => {
+	test("seeds theme and resolvedTheme from initialTheme", () => {
+		const html = renderToStaticMarkup(
+			<ExtendedClientNextThemeProvider storage="none" initialTheme="dark">
+				<ThemeConsumer />
+			</ExtendedClientNextThemeProvider>,
+		);
+		expect(html).toContain('data-testid="theme">dark</span>');
+		expect(html).toContain('data-testid="resolved">dark</span>');
+	});
+
+	test("forcedTheme wins over initialTheme", () => {
+		const html = renderToStaticMarkup(
+			<ExtendedClientNextThemeProvider
+				storage="none"
+				forcedTheme="dark"
+				initialTheme="light"
+			>
+				<ThemeConsumer />
+			</ExtendedClientNextThemeProvider>,
+		);
+		expect(html).toContain('data-testid="theme">dark</span>');
+		expect(html).toContain('data-testid="resolved">dark</span>');
 	});
 });

--- a/packages/themes/src/__tests__/client-next-provider.test.tsx
+++ b/packages/themes/src/__tests__/client-next-provider.test.tsx
@@ -284,11 +284,7 @@ describe("ExtendedClientNextThemeProvider - SSR snapshots", () => {
 
 	test("forcedTheme wins over initialTheme", () => {
 		const html = renderToStaticMarkup(
-			<ExtendedClientNextThemeProvider
-				storage="none"
-				forcedTheme="dark"
-				initialTheme="light"
-			>
+			<ExtendedClientNextThemeProvider storage="none" forcedTheme="dark" initialTheme="light">
 				<ThemeConsumer />
 			</ExtendedClientNextThemeProvider>,
 		);

--- a/packages/themes/src/__tests__/client-provider.test.tsx
+++ b/packages/themes/src/__tests__/client-provider.test.tsx
@@ -1,8 +1,11 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
 import type { ReactNode } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { ThemedImage } from "../components/themed-image.js";
 import { useTheme } from "../core/context.js";
 import { serializeCookie, writeCookie } from "../core/cookie.js";
+import { useThemeValue } from "../hooks/use-theme-value.js";
 import { ClientThemeProvider } from "../providers/client-provider.js";
 import { clearCookies } from "./setup.js";
 
@@ -70,6 +73,15 @@ function ThemeConsumer({ prefix = "" }: { prefix?: string }) {
 			</button>
 		</div>
 	);
+}
+
+function ValueReader({
+	values,
+}: {
+	values: Partial<Record<"light" | "dark" | "system" | "default", string>>;
+}) {
+	const value = useThemeValue(values);
+	return <span data-testid="value">{value ?? "-"}</span>;
 }
 
 function InvalidThemeConsumer() {
@@ -420,6 +432,98 @@ describe("ClientThemeProvider - initialTheme", () => {
 		});
 		expect(screen.getByTestId("theme").textContent).toBe("light");
 		expect(localStorage.getItem("theme")).toBe("light");
+	});
+});
+
+describe("ClientThemeProvider - SSR snapshots", () => {
+	test("seeds theme and resolvedTheme from initialTheme", () => {
+		const html = renderToStaticMarkup(
+			<ClientThemeProvider storage="none" initialTheme="dark">
+				<ThemeConsumer />
+			</ClientThemeProvider>,
+		);
+		expect(html).toContain('data-testid="theme">dark</span>');
+		expect(html).toContain('data-testid="resolved">dark</span>');
+	});
+
+	test("leaves theme unknown when neither initialTheme nor forcedTheme is set", () => {
+		const html = renderToStaticMarkup(
+			<ClientThemeProvider storage="none">
+				<ThemeConsumer />
+			</ClientThemeProvider>,
+		);
+		expect(html).toContain('data-testid="theme">-</span>');
+		expect(html).toContain('data-testid="resolved">-</span>');
+	});
+
+	test("seeds theme and resolvedTheme from forcedTheme", () => {
+		const html = renderToStaticMarkup(
+			<ClientThemeProvider storage="none" forcedTheme="dark">
+				<ThemeConsumer />
+			</ClientThemeProvider>,
+		);
+		expect(html).toContain('data-testid="theme">dark</span>');
+		expect(html).toContain('data-testid="resolved">dark</span>');
+	});
+
+	test("forcedTheme wins over initialTheme", () => {
+		const html = renderToStaticMarkup(
+			<ClientThemeProvider storage="none" forcedTheme="dark" initialTheme="light">
+				<ThemeConsumer />
+			</ClientThemeProvider>,
+		);
+		expect(html).toContain('data-testid="theme">dark</span>');
+		expect(html).toContain('data-testid="resolved">dark</span>');
+	});
+
+	test("initialTheme=system reports theme but not resolvedTheme", () => {
+		const html = renderToStaticMarkup(
+			<ClientThemeProvider storage="none" initialTheme="system">
+				<ThemeConsumer />
+			</ClientThemeProvider>,
+		);
+		expect(html).toContain('data-testid="theme">system</span>');
+		expect(html).toContain('data-testid="resolved">-</span>');
+	});
+
+	test("ignores initialTheme that is not in the themes list", () => {
+		const html = renderToStaticMarkup(
+			<ClientThemeProvider storage="none" initialTheme={"invalid" as "light"}>
+				<ThemeConsumer />
+			</ClientThemeProvider>,
+		);
+		expect(html).toContain('data-testid="theme">-</span>');
+		expect(html).toContain('data-testid="resolved">-</span>');
+	});
+
+	test("ThemedImage uses the seeded theme source", () => {
+		const html = renderToStaticMarkup(
+			<ClientThemeProvider storage="none" initialTheme="dark">
+				<ThemedImage src={{ light: "/light.png", dark: "/dark.png" }} alt="Theme preview" />
+			</ClientThemeProvider>,
+		);
+		expect(html).toContain('src="/dark.png"');
+		expect(html).not.toContain("data:image/gif");
+	});
+
+	test("ThemedImage keeps the placeholder when initialTheme is system", () => {
+		const html = renderToStaticMarkup(
+			<ClientThemeProvider storage="none" initialTheme="system">
+				<ThemedImage src={{ light: "/light.png", dark: "/dark.png" }} alt="Theme preview" />
+			</ClientThemeProvider>,
+		);
+		expect(html).toContain("data:image/gif");
+		expect(html).not.toContain("/dark.png");
+		expect(html).not.toContain("/light.png");
+	});
+
+	test("useThemeValue returns the seeded resolved value", () => {
+		const html = renderToStaticMarkup(
+			<ClientThemeProvider storage="none" initialTheme="dark">
+				<ValueReader values={{ light: "Light", dark: "Dark" }} />
+			</ClientThemeProvider>,
+		);
+		expect(html).toContain('data-testid="value">Dark</span>');
 	});
 });
 

--- a/packages/themes/src/__tests__/store.test.ts
+++ b/packages/themes/src/__tests__/store.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from "bun:test";
+import { createThemeStore } from "../core/store.js";
+
+describe("createThemeStore", () => {
+	test("unseeded snapshots are empty and getServerSnapshot is reference-stable", () => {
+		const store = createThemeStore();
+		const server = store.getServerSnapshot();
+		const client = store.getSnapshot();
+
+		expect(server).toEqual({ theme: undefined, systemTheme: undefined });
+		expect(client).toEqual({ theme: undefined, systemTheme: undefined });
+		expect(store.getServerSnapshot()).toBe(server);
+		expect(store.getSnapshot()).toBe(server);
+	});
+
+	test("seeded snapshots share one object until the first setState", () => {
+		const store = createThemeStore("dark");
+		const server = store.getServerSnapshot();
+		const client = store.getSnapshot();
+
+		expect(client).toBe(server);
+		expect(server).toEqual({ theme: "dark", systemTheme: undefined });
+		expect(store.getServerSnapshot()).toBe(server);
+	});
+
+	test("setTheme updates the client snapshot without mutating the server snapshot", () => {
+		const store = createThemeStore("dark");
+		const server = store.getServerSnapshot();
+
+		store.setTheme("light");
+
+		expect(store.getSnapshot()).toEqual({ theme: "light", systemTheme: undefined });
+		expect(store.getServerSnapshot()).toBe(server);
+		expect(server).toEqual({ theme: "dark", systemTheme: undefined });
+	});
+});

--- a/packages/themes/src/__tests__/use-theme-value.test.tsx
+++ b/packages/themes/src/__tests__/use-theme-value.test.tsx
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import "./setup.js";
 import { cleanup, render } from "@testing-library/react";
+import { renderToStaticMarkup } from "react-dom/server";
 import { useThemeValue } from "../hooks/use-theme-value.js";
 import { ClientThemeProvider } from "../providers/client-provider.js";
 
@@ -59,5 +60,14 @@ describe("useThemeValue", () => {
 		);
 
 		expect(view.getByTestId("value").textContent).toBe("Fallback");
+	});
+
+	test("returns the seeded resolved value during SSR", () => {
+		const html = renderToStaticMarkup(
+			<ClientThemeProvider storage="none" initialTheme="dark">
+				<ValueReader values={{ light: "Light", dark: "Dark" }} />
+			</ClientThemeProvider>,
+		);
+		expect(html).toContain('data-testid="value">Dark</span>');
 	});
 });

--- a/packages/themes/src/components/themed-image.tsx
+++ b/packages/themes/src/components/themed-image.tsx
@@ -4,7 +4,7 @@ import type { ImgHTMLAttributes, ReactElement } from "react";
 import { ThemeContext, type ThemeContextInstance, useThemeFromContext } from "../core/context.js";
 import type { ResolvedTheme } from "../core/types.js";
 
-// Transparent 1x1 GIF - shown before theme resolves to avoid hydration mismatch
+// Transparent 1x1 GIF - shown while resolvedTheme is unknown to avoid hydration mismatch
 const TRANSPARENT_FALLBACK =
 	"data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7";
 
@@ -15,7 +15,7 @@ export type ThemedImageProps<Themes extends string = string> = Omit<
 	/** Map of theme name to image source */
 	src: Record<ResolvedTheme<Themes>, string>;
 	/**
-	 * Shown before the theme resolves on the client.
+	 * Shown while resolvedTheme is unknown.
 	 * Defaults to a transparent 1x1 GIF to avoid hydration mismatch.
 	 */
 	fallback?: string;

--- a/packages/themes/src/core/store.ts
+++ b/packages/themes/src/core/store.ts
@@ -3,8 +3,6 @@ type ThemeState = {
 	systemTheme: "light" | "dark" | undefined;
 };
 
-const SERVER_SNAPSHOT: ThemeState = { theme: undefined, systemTheme: undefined };
-
 export type ThemeStore = {
 	subscribe(listener: () => void): () => void;
 	getSnapshot(): ThemeState;
@@ -14,8 +12,9 @@ export type ThemeStore = {
 	setSystemTheme(systemTheme: "light" | "dark" | undefined): void;
 };
 
-export function createThemeStore(): ThemeStore {
-	let state: ThemeState = { theme: undefined, systemTheme: undefined };
+export function createThemeStore(seedTheme?: string): ThemeStore {
+	const serverSnapshot: ThemeState = { theme: seedTheme, systemTheme: undefined };
+	let state: ThemeState = serverSnapshot;
 	const listeners = new Set<() => void>();
 
 	function emit(): void {
@@ -41,7 +40,7 @@ export function createThemeStore(): ThemeStore {
 		},
 
 		getServerSnapshot(): ThemeState {
-			return SERVER_SNAPSHOT;
+			return serverSnapshot;
 		},
 
 		setState(nextState: ThemeState): void {

--- a/packages/themes/src/core/store.ts
+++ b/packages/themes/src/core/store.ts
@@ -16,43 +16,21 @@ export function createThemeStore(seedTheme?: string): ThemeStore {
 	const serverSnapshot: ThemeState = { theme: seedTheme, systemTheme: undefined };
 	let state: ThemeState = serverSnapshot;
 	const listeners = new Set<() => void>();
-
-	function emit(): void {
-		for (const listener of listeners) listener();
-	}
-
-	function setState(nextState: ThemeState): void {
+	const setState = (nextState: ThemeState): void => {
 		if (state.theme === nextState.theme && state.systemTheme === nextState.systemTheme) return;
 		state = nextState;
-		emit();
-	}
+		for (const listener of listeners) listener();
+	};
 
 	return {
-		subscribe(listener: () => void): () => void {
+		subscribe(listener) {
 			listeners.add(listener);
-			return () => {
-				listeners.delete(listener);
-			};
+			return () => void listeners.delete(listener);
 		},
-
-		getSnapshot(): ThemeState {
-			return state;
-		},
-
-		getServerSnapshot(): ThemeState {
-			return serverSnapshot;
-		},
-
-		setState(nextState: ThemeState): void {
-			setState(nextState);
-		},
-
-		setTheme(theme: string | undefined): void {
-			setState({ ...state, theme });
-		},
-
-		setSystemTheme(systemTheme: "light" | "dark" | undefined): void {
-			setState({ ...state, systemTheme });
-		},
+		getSnapshot: () => state,
+		getServerSnapshot: () => serverSnapshot,
+		setState,
+		setTheme: (theme) => setState({ ...state, theme }),
+		setSystemTheme: (systemTheme) => setState({ ...state, systemTheme }),
 	};
 }

--- a/packages/themes/src/core/types.ts
+++ b/packages/themes/src/core/types.ts
@@ -77,7 +77,7 @@ export type ThemeProviderProps<Themes extends string = DefaultTheme> = {
 	themeColor?: ThemeColor<Themes>;
 	/** Always follow system preference changes, even after setTheme was called */
 	followSystem?: boolean;
-	/** Server-provided theme that overrides storage on mount (e.g. from a database). User can still call setTheme to change it. */
+	/** Server-provided theme that seeds the store snapshot and overrides storage on mount (e.g. from a database). User can still call setTheme to change it. */
 	initialTheme?: ThemeSelection<Themes>;
 	/** Cookie options, used when storage is "cookie" or "hybrid" */
 	cookieOptions?: CookieOptions;

--- a/packages/themes/src/providers/client-provider.tsx
+++ b/packages/themes/src/providers/client-provider.tsx
@@ -68,9 +68,15 @@ export function ClientThemeProvider<Themes extends string = DefaultTheme>({
 }: ClientThemeProviderProps<Themes>): ReactElement {
 	const resolvedDefault = resolveDefaultTheme(themes, enableSystem, defaultTheme);
 
+	const validForcedTheme = forcedTheme && themes.includes(forcedTheme) ? forcedTheme : undefined;
 	const storeRef = useRef<ReturnType<typeof createThemeStore> | null>(null);
 	if (storeRef.current === null) {
-		storeRef.current = createThemeStore();
+		storeRef.current = createThemeStore(
+			validForcedTheme ??
+				(initialTheme && isThemeSelection(initialTheme, themes, enableSystem)
+					? initialTheme
+					: undefined),
+		);
 	}
 	const store = storeRef.current;
 	const {
@@ -86,8 +92,6 @@ export function ClientThemeProvider<Themes extends string = DefaultTheme>({
 		store.getServerSnapshot,
 	);
 	const lastAppliedRef = useRef<LastAppliedTheme | null>(null);
-
-	const validForcedTheme = forcedTheme && themes.includes(forcedTheme) ? forcedTheme : undefined;
 	const selectedTheme = validForcedTheme ?? theme;
 	const resolvedTheme: ResolvedTheme<Themes> | undefined =
 		selectedTheme === "system" || selectedTheme === undefined

--- a/packages/themes/src/providers/client-provider.tsx
+++ b/packages/themes/src/providers/client-provider.tsx
@@ -70,7 +70,7 @@ export function ClientThemeProvider<Themes extends string = DefaultTheme>({
 
 	const validForcedTheme = forcedTheme && themes.includes(forcedTheme) ? forcedTheme : undefined;
 	const storeRef = useRef<ReturnType<typeof createThemeStore> | null>(null);
-	if (storeRef.current === null) {
+	if (!storeRef.current) {
 		storeRef.current = createThemeStore(
 			validForcedTheme ??
 				(initialTheme && isThemeSelection(initialTheme, themes, enableSystem)

--- a/packages/themes/src/providers/extended-client-provider.tsx
+++ b/packages/themes/src/providers/extended-client-provider.tsx
@@ -90,7 +90,7 @@ export function ExtendedClientThemeProvider<Themes extends string = DefaultTheme
 
 	const validForcedTheme = forcedTheme && themes.includes(forcedTheme) ? forcedTheme : undefined;
 	const storeRef = useRef<ReturnType<typeof createThemeStore> | null>(null);
-	if (storeRef.current === null) {
+	if (!storeRef.current) {
 		storeRef.current = createThemeStore(
 			validForcedTheme ??
 				(initialTheme && isThemeSelection(initialTheme, themes, enableSystem)

--- a/packages/themes/src/providers/extended-client-provider.tsx
+++ b/packages/themes/src/providers/extended-client-provider.tsx
@@ -88,9 +88,15 @@ export function ExtendedClientThemeProvider<Themes extends string = DefaultTheme
 }: ExtendedThemeProviderProps<Themes>): ReactElement {
 	const resolvedDefault = resolveDefaultTheme(themes, enableSystem, defaultTheme);
 
+	const validForcedTheme = forcedTheme && themes.includes(forcedTheme) ? forcedTheme : undefined;
 	const storeRef = useRef<ReturnType<typeof createThemeStore> | null>(null);
 	if (storeRef.current === null) {
-		storeRef.current = createThemeStore();
+		storeRef.current = createThemeStore(
+			validForcedTheme ??
+				(initialTheme && isThemeSelection(initialTheme, themes, enableSystem)
+					? initialTheme
+					: undefined),
+		);
 	}
 	const store = storeRef.current;
 	const appliedThemeRef = useRef<AppliedThemeState | undefined>(undefined);
@@ -107,8 +113,6 @@ export function ExtendedClientThemeProvider<Themes extends string = DefaultTheme
 		store.getSnapshot,
 		store.getServerSnapshot,
 	);
-
-	const validForcedTheme = forcedTheme && themes.includes(forcedTheme) ? forcedTheme : undefined;
 	const selectedTheme = validForcedTheme ?? theme;
 	const resolvedTheme = selectedTheme
 		? (resolveSelection(


### PR DESCRIPTION
## Summary
- Seed the theme store's server and first-client snapshots from `forcedTheme ?? initialTheme` so `useTheme`, `useThemeValue`, and `ThemedImage` work during SSR when the theme is already known.
- `"system"` still leaves `resolvedTheme` unknown until `matchMedia` runs; storage-backed themes stay unknown until mount.
- Docs now describe this as the source of truth instead of "always undefined before hydration."

## Test plan
- [ ] `bun run --cwd packages/themes test` (store unit tests + `renderToStaticMarkup` SSR cases on both providers, ThemedImage, and `useThemeValue`)
- [ ] Existing mount tests for `initialTheme` / `forcedTheme` and bootstrap-runtime-parity still pass
- [ ] `bun run --cwd packages/themes type-check` and `bun run lint`
- [ ] `bun run --cwd packages/themes size:compare` stays under gzip ceilings (no threshold bump)