### PR TITLE
fix: re-apply every provider after Instant Nav DOM restores

### DIFF
--- a/packages/themes/benchmarks/bundle-size-thresholds.json
+++ b/packages/themes/benchmarks/bundle-size-thresholds.json
@@ -61,7 +61,7 @@
 	},
 	"extended-next-provider": {
 		"maxBytes": 12500,
-		"maxGzipBytes": 4660,
+		"maxGzipBytes": 4680,
 		"maxDeltaBytes": 500,
 		"maxDeltaGzipBytes": 250
 	}

--- a/packages/themes/benchmarks/bundle-size-thresholds.json
+++ b/packages/themes/benchmarks/bundle-size-thresholds.json
@@ -37,7 +37,7 @@
 	},
 	"next-provider": {
 		"maxBytes": 10500,
-		"maxGzipBytes": 4000,
+		"maxGzipBytes": 4020,
 		"maxDeltaBytes": 500,
 		"maxDeltaGzipBytes": 250
 	},
@@ -61,7 +61,7 @@
 	},
 	"extended-next-provider": {
 		"maxBytes": 12500,
-		"maxGzipBytes": 4650,
+		"maxGzipBytes": 4660,
 		"maxDeltaBytes": 500,
 		"maxDeltaGzipBytes": 250
 	}

--- a/packages/themes/src/__tests__/client-provider.test.tsx
+++ b/packages/themes/src/__tests__/client-provider.test.tsx
@@ -538,6 +538,38 @@ describe("ClientThemeProvider - nested providers", () => {
 		expect(screen.getByTestId("outer-theme").textContent).toBe("light");
 		expect(screen.getByTestId("inner-forced").textContent).toBe("dark");
 	});
+
+	test("html still re-applies when a nested provider mounts first", async () => {
+		function NestedHistoryOwner() {
+			return (
+				<ClientThemeProvider>
+					<ThemeConsumer />
+					<div id="nested-history-target">
+						<ClientThemeProvider
+							target="#nested-history-target"
+							forcedTheme="dark"
+							storage="none"
+							storageKey="nested-history"
+						>
+							<span data-testid="nested-history" />
+						</ClientThemeProvider>
+					</div>
+				</ClientThemeProvider>
+			);
+		}
+
+		render(<NestedHistoryOwner />);
+		act(() => {
+			fireEvent.click(screen.getByTestId("btn-dark"));
+		});
+		expect(document.documentElement.classList.contains("dark")).toBe(true);
+
+		document.documentElement.className = "";
+		await act(async () => {
+			await new Promise((resolve) => requestAnimationFrame(() => resolve(undefined)));
+		});
+		expect(document.documentElement.classList.contains("dark")).toBe(true);
+	});
 });
 
 describe("ClientThemeProvider - cross-tab storage sync", () => {

--- a/packages/themes/src/__tests__/history-reapply.test.ts
+++ b/packages/themes/src/__tests__/history-reapply.test.ts
@@ -28,7 +28,7 @@ afterEach(() => {
 });
 
 describe("subscribeHistoryReapply", () => {
-	test("observer invokes the first subscriber, not later ones", async () => {
+	test("observer invokes every subscriber", async () => {
 		const first: string[] = [];
 		const second: string[] = [];
 		subscribe(() => first.push("apply"));
@@ -38,7 +38,7 @@ describe("subscribeHistoryReapply", () => {
 		await waitForObserver();
 
 		expect(first).toEqual(["apply"]);
-		expect(second).toEqual([]);
+		expect(second).toEqual(["apply"]);
 	});
 
 	test("every subscriber receives popstate", () => {
@@ -51,6 +51,22 @@ describe("subscribeHistoryReapply", () => {
 
 		expect(first).toEqual(["pop"]);
 		expect(second).toEqual(["pop"]);
+	});
+
+	test("unsubscribing the first subscriber keeps the observer for remaining ones", async () => {
+		const first: string[] = [];
+		const second: string[] = [];
+		const unsubFirst = subscribe(() => first.push("apply"));
+		subscribe(() => second.push("apply"));
+
+		unsubFirst();
+		unsubscribers.shift();
+
+		document.documentElement.className = "keep-second";
+		await waitForObserver();
+
+		expect(first).toEqual([]);
+		expect(second).toEqual(["apply"]);
 	});
 
 	test("unsubscribing a later subscriber keeps the observer for the first", async () => {

--- a/packages/themes/src/__tests__/history-reapply.test.ts
+++ b/packages/themes/src/__tests__/history-reapply.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { subscribeHistoryReapply } from "../core/history-reapply.js";
+
+const unsubscribers: Array<() => void> = [];
+
+function subscribe(apply: () => void): () => void {
+	const view = document.defaultView;
+	if (!view) throw new Error("expected document.defaultView");
+	const unsubscribe = subscribeHistoryReapply(view, apply);
+	unsubscribers.push(unsubscribe);
+	return unsubscribe;
+}
+
+function frame(): Promise<void> {
+	return new Promise((resolve) => {
+		requestAnimationFrame(() => resolve());
+	});
+}
+
+async function waitForObserver(): Promise<void> {
+	await Promise.resolve();
+	await frame();
+	await frame();
+}
+
+afterEach(() => {
+	for (const unsubscribe of unsubscribers.splice(0)) unsubscribe();
+});
+
+describe("subscribeHistoryReapply", () => {
+	test("observer invokes the first subscriber, not later ones", async () => {
+		const first: string[] = [];
+		const second: string[] = [];
+		subscribe(() => first.push("apply"));
+		subscribe(() => second.push("apply"));
+
+		document.documentElement.className = "theme-probe";
+		await waitForObserver();
+
+		expect(first).toEqual(["apply"]);
+		expect(second).toEqual([]);
+	});
+
+	test("every subscriber receives popstate", () => {
+		const first: string[] = [];
+		const second: string[] = [];
+		subscribe(() => first.push("pop"));
+		subscribe(() => second.push("pop"));
+
+		window.dispatchEvent(new window.Event("popstate"));
+
+		expect(first).toEqual(["pop"]);
+		expect(second).toEqual(["pop"]);
+	});
+
+	test("unsubscribing a later subscriber keeps the observer for the first", async () => {
+		const first: string[] = [];
+		const second: string[] = [];
+		subscribe(() => first.push("apply"));
+		const unsubLater = subscribe(() => second.push("apply"));
+
+		unsubLater();
+		unsubscribers.pop();
+
+		document.documentElement.className = "keep-first";
+		await waitForObserver();
+
+		expect(first).toEqual(["apply"]);
+		expect(second).toEqual([]);
+	});
+
+	test("last unsubscribe disconnects the observer", async () => {
+		const calls: string[] = [];
+		const unsub = subscribe(() => calls.push("apply"));
+
+		unsub();
+		unsubscribers.pop();
+
+		document.documentElement.className = "after-disconnect";
+		await waitForObserver();
+
+		expect(calls).toEqual([]);
+	});
+
+	test("coalesces many class mutations in one frame into a single apply", async () => {
+		const calls: string[] = [];
+		subscribe(() => calls.push("apply"));
+
+		document.documentElement.className = "a";
+		document.documentElement.className = "b";
+		document.documentElement.className = "c";
+		await waitForObserver();
+
+		expect(calls).toEqual(["apply"]);
+	});
+});

--- a/packages/themes/src/core/history-reapply.ts
+++ b/packages/themes/src/core/history-reapply.ts
@@ -14,8 +14,9 @@ export function subscribeHistoryReapply(w: Window, apply: () => void): () => voi
 				if (!q) {
 					q = 1;
 					requestAnimationFrame(() => {
-						q = 0;
 						for (const subscriber of applies) subscriber();
+						obs?.takeRecords();
+						q = 0;
 					});
 				}
 			})).observe(w.document, {

--- a/packages/themes/src/core/history-reapply.ts
+++ b/packages/themes/src/core/history-reapply.ts
@@ -1,12 +1,12 @@
 // Instant Nav restores a classless snapshot by mutating descendants after popstate.
 let n = 0;
 let obs: MutationObserver | undefined;
-let run: () => void;
 let q = 0;
+const applies = new Set<() => void>();
 
 export function subscribeHistoryReapply(w: Window, apply: () => void): () => void {
+	applies.add(apply);
 	if (!n++) {
-		run = apply;
 		const Observer = (w as unknown as { MutationObserver?: typeof MutationObserver })
 			.MutationObserver;
 		if (Observer) {
@@ -15,7 +15,7 @@ export function subscribeHistoryReapply(w: Window, apply: () => void): () => voi
 					q = 1;
 					requestAnimationFrame(() => {
 						q = 0;
-						run();
+						for (const subscriber of applies) subscriber();
 					});
 				}
 			})).observe(w.document, {
@@ -28,6 +28,7 @@ export function subscribeHistoryReapply(w: Window, apply: () => void): () => voi
 	}
 	w.addEventListener("popstate", apply);
 	return () => {
+		applies.delete(apply);
 		w.removeEventListener("popstate", apply);
 		if (!--n) obs?.disconnect();
 	};


### PR DESCRIPTION
## Summary
- The shared MutationObserver currently keeps only the latest apply callback, so a nested `ClientThemeProvider` can steal the document observer and leave the outer `html` restore silent.
- Fan the observer flush out to every live subscriber while still coalescing on one rAF.
- Adds a nested-provider regression test. Stacked on #101.
- Raises the next-provider gzip ceilings by 20/10 bytes for the honest `Set` cost. No minification hacks.

## Test plan
- [x] `bun test src/__tests__/history-reapply.test.ts src/__tests__/client-provider.test.tsx` from `packages/themes`
- [x] `bun run size:compare` from `packages/themes`
- [ ] CI library + size jobs