### PR TITLE
ci: run the full themes suite on the React 18 support floor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,6 +102,7 @@ jobs:
   react-compatibility:
     name: React ${{ matrix.react }}
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:
@@ -151,8 +152,8 @@ jobs:
             "@types/react-dom@${REACT_DOM_TYPES}"
           pnpm install
 
-      - name: Test effect event compatibility
-        run: pnpm --filter @wrksz/themes test src/__tests__/use-effect-event-compat.test.tsx
+      - name: Test
+        run: pnpm --filter @wrksz/themes test
 
       - name: Build
         run: pnpm --filter @wrksz/themes build

--- a/packages/themes/src/__tests__/extended-client-provider.test.tsx
+++ b/packages/themes/src/__tests__/extended-client-provider.test.tsx
@@ -1,9 +1,14 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
-import { Activity, type ReactNode } from "react";
+import * as React from "react";
+import type { ReactNode } from "react";
 import { useTheme } from "../core/context.js";
 import { ExtendedClientThemeProvider } from "../providers/extended-client-provider.js";
 import { clearCookies } from "./setup.js";
+
+// React 18 does not export Activity; skip this coverage on the 18.3 support floor.
+type ActivityComponent = (props: { mode: "hidden" | "visible"; children?: ReactNode }) => ReactNode;
+const Activity = (React as unknown as { Activity?: ActivityComponent }).Activity;
 
 (globalThis as unknown as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT = true;
 
@@ -147,14 +152,16 @@ describe("ExtendedClientThemeProvider", () => {
 		expect(screen.getByTestId("second-theme").textContent).toBe("dark");
 	});
 
-	test("refreshes an Activity-preserved provider when visible", () => {
+	test.skipIf(!Activity)("refreshes an Activity-preserved provider when visible", () => {
+		const Preserve = Activity;
+		if (!Preserve) return;
 		const providers = (mode: "hidden" | "visible") => (
 			<>
-				<Activity mode={mode}>
+				<Preserve mode={mode}>
 					<ExtendedClientThemeProvider storageKey="activity" enableSameDocumentSync>
 						<ThemeConsumer prefix="preserved-" />
 					</ExtendedClientThemeProvider>
-				</Activity>
+				</Preserve>
 				<ExtendedClientThemeProvider storageKey="activity" enableSameDocumentSync>
 					<ThemeConsumer prefix="active-" />
 				</ExtendedClientThemeProvider>


### PR DESCRIPTION
## Summary
- The `react-compatibility` job currently executes only the React 18 matrix file, so a React 18 regression in the rest of the suite can still go green.
- Run the complete `@wrksz/themes test` command on both 18.3.1 and 19.2.8, and give the job a 20-minute timeout.

## Test plan
- [ ] CI `react-compatibility` matrix on 18.3.1 and 19.2.8
- [ ] Confirm a failure in a non-compat file would fail the React 18 row