### PR TITLE
perf: skip DOM apply when theme config is value-equal

### DIFF
--- a/packages/themes/benchmarks/baseline.json
+++ b/packages/themes/benchmarks/baseline.json
@@ -31,27 +31,27 @@
 	},
 	{
 		"name": "next-provider",
-		"bytes": 9945,
-		"gzipBytes": 3799
+		"bytes": 10929,
+		"gzipBytes": 4179
 	},
 	{
 		"name": "script",
-		"bytes": 3007,
-		"gzipBytes": 1415
+		"bytes": 3039,
+		"gzipBytes": 1394
 	},
 	{
 		"name": "client-provider",
-		"bytes": 6508,
-		"gzipBytes": 2731
-	},
-	{
-		"name": "generated-script",
-		"bytes": 1772,
-		"gzipBytes": 927
+		"bytes": 7519,
+		"gzipBytes": 3137
 	},
 	{
 		"name": "extended-next-provider",
-		"bytes": 12253,
-		"gzipBytes": 4506
+		"bytes": 12922,
+		"gzipBytes": 4836
+	},
+	{
+		"name": "generated-script",
+		"bytes": 1482,
+		"gzipBytes": 746
 	}
 ]

--- a/packages/themes/benchmarks/bundle-size-thresholds.json
+++ b/packages/themes/benchmarks/bundle-size-thresholds.json
@@ -36,8 +36,8 @@
 		"maxDeltaGzipBytes": 120
 	},
 	"next-provider": {
-		"maxBytes": 10500,
-		"maxGzipBytes": 4000,
+		"maxBytes": 11000,
+		"maxGzipBytes": 4200,
 		"maxDeltaBytes": 500,
 		"maxDeltaGzipBytes": 250
 	},
@@ -60,8 +60,8 @@
 		"maxDeltaGzipBytes": 120
 	},
 	"extended-next-provider": {
-		"maxBytes": 12500,
-		"maxGzipBytes": 4650,
+		"maxBytes": 13000,
+		"maxGzipBytes": 4850,
 		"maxDeltaBytes": 500,
 		"maxDeltaGzipBytes": 250
 	}

--- a/packages/themes/src/__tests__/client-provider.test.tsx
+++ b/packages/themes/src/__tests__/client-provider.test.tsx
@@ -317,6 +317,43 @@ describe("ClientThemeProvider - setTheme", () => {
 		expect(contextIdentitySeen.at(-1)).toBe(afterInit);
 	});
 
+	test("keeps context identity when themes/value/themeColor rerender with equal contents", () => {
+		contextIdentitySeen.length = 0;
+		const view = render(
+			<ClientThemeProvider
+				defaultTheme="light"
+				enableSystem={false}
+				themes={["light", "dark"]}
+				value={{ dark: "dark" }}
+				themeColor={{ dark: "#000" }}
+			>
+				<ContextIdentityProbe />
+			</ClientThemeProvider>,
+		);
+		const afterInit = contextIdentitySeen.at(-1);
+		expect(afterInit).toBeDefined();
+		const spy = spyClassListMutations(document.documentElement);
+		try {
+			view.rerender(
+				<ClientThemeProvider
+					defaultTheme="light"
+					enableSystem={false}
+					themes={["light", "dark"]}
+					value={{ dark: "dark" }}
+					themeColor={{ dark: "#000" }}
+				>
+					<ContextIdentityProbe />
+				</ClientThemeProvider>,
+			);
+
+			expect(contextIdentitySeen.at(-1)).toBe(afterInit);
+			expect(spy.added).toHaveLength(0);
+			expect(spy.removed).toHaveLength(0);
+		} finally {
+			spy.restore();
+		}
+	});
+
 	test("saves to localStorage", () => {
 		wrap(<ThemeConsumer />);
 		act(() => {

--- a/packages/themes/src/__tests__/config-equal.test.ts
+++ b/packages/themes/src/__tests__/config-equal.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "bun:test";
+import {
+	holdIfEqual,
+	sameStringList,
+	sameStringRecord,
+	sameThemeColor,
+} from "../core/config-equal.js";
+
+describe("config-equal", () => {
+	test("sameStringList compares by contents", () => {
+		expect(sameStringList(["light", "dark"], ["light", "dark"])).toBe(true);
+		expect(sameStringList(["light", "dark"], ["dark", "light"])).toBe(false);
+	});
+
+	test("sameStringRecord compares by contents", () => {
+		expect(sameStringRecord({ dark: "night" }, { dark: "night" })).toBe(true);
+		expect(sameStringRecord({ dark: "night" }, { dark: "day" })).toBe(false);
+		expect(sameStringRecord(undefined, { dark: "night" })).toBe(false);
+	});
+
+	test("sameThemeColor compares strings and maps", () => {
+		expect(sameThemeColor("#000", "#000")).toBe(true);
+		expect(sameThemeColor({ dark: "#000" }, { dark: "#000" })).toBe(true);
+		expect(sameThemeColor("#000", { dark: "#000" })).toBe(false);
+	});
+
+	test("holdIfEqual reuses the previous reference when equal", () => {
+		const previous = ["light", "dark"];
+		expect(holdIfEqual(previous, ["light", "dark"], sameStringList)).toBe(previous);
+		expect(holdIfEqual(previous, ["light", "high-contrast"], sameStringList)).not.toBe(
+			previous,
+		);
+	});
+});

--- a/packages/themes/src/core/config-equal.ts
+++ b/packages/themes/src/core/config-equal.ts
@@ -1,0 +1,36 @@
+export function sameStringList(left: readonly string[], right: readonly string[]): boolean {
+	if (left === right) return true;
+	if (left.length !== right.length) return false;
+	for (let index = 0; index < left.length; index += 1) {
+		if (left[index] !== right[index]) return false;
+	}
+	return true;
+}
+
+export function sameStringRecord(
+	left: Partial<Record<string, string>> | undefined,
+	right: Partial<Record<string, string>> | undefined,
+): boolean {
+	if (left === right) return true;
+	if (!left || !right) return false;
+	const leftKeys = Object.keys(left);
+	const rightKeys = Object.keys(right);
+	if (leftKeys.length !== rightKeys.length) return false;
+	for (const key of leftKeys) {
+		if (left[key] !== right[key]) return false;
+	}
+	return true;
+}
+
+export function sameThemeColor(
+	left: string | Partial<Record<string, string>> | undefined,
+	right: string | Partial<Record<string, string>> | undefined,
+): boolean {
+	if (left === right) return true;
+	if (typeof left === "string" || typeof right === "string") return false;
+	return sameStringRecord(left, right);
+}
+
+export function holdIfEqual<T>(previous: T, next: T, equal: (left: T, right: T) => boolean): T {
+	return equal(previous, next) ? previous : next;
+}

--- a/packages/themes/src/providers/client-provider.tsx
+++ b/packages/themes/src/providers/client-provider.tsx
@@ -14,6 +14,12 @@ import {
 	readStoredTheme,
 	writeStoredTheme,
 } from "../core/client-dom.js";
+import {
+	holdIfEqual,
+	sameStringList,
+	sameStringRecord,
+	sameThemeColor,
+} from "../core/config-equal.js";
 import { ThemeContext, type ThemeContextInstance } from "../core/context.js";
 import { subscribeHistoryReapply } from "../core/history-reapply.js";
 import { createThemeStore } from "../core/store.js";
@@ -86,8 +92,18 @@ export function ClientThemeProvider<Themes extends string = DefaultTheme>({
 		store.getServerSnapshot,
 	);
 	const lastAppliedRef = useRef<LastAppliedTheme | null>(null);
+	const themesRef = useRef(themes);
+	themesRef.current = holdIfEqual(themesRef.current, themes, sameStringList);
+	const stableThemes = themesRef.current;
+	const valueMapRef = useRef(valueMap);
+	valueMapRef.current = holdIfEqual(valueMapRef.current, valueMap, sameStringRecord);
+	const stableValueMap = valueMapRef.current;
+	const themeColorRef = useRef(themeColor);
+	themeColorRef.current = holdIfEqual(themeColorRef.current, themeColor, sameThemeColor);
+	const stableThemeColor = themeColorRef.current;
 
-	const validForcedTheme = forcedTheme && themes.includes(forcedTheme) ? forcedTheme : undefined;
+	const validForcedTheme =
+		forcedTheme && stableThemes.includes(forcedTheme) ? forcedTheme : undefined;
 	const selectedTheme = validForcedTheme ?? theme;
 	const resolvedTheme: ResolvedTheme<Themes> | undefined =
 		selectedTheme === "system" || selectedTheme === undefined
@@ -102,12 +118,12 @@ export function ClientThemeProvider<Themes extends string = DefaultTheme>({
 		const last: LastAppliedTheme = {
 			resolved,
 			attribute,
-			themes,
-			valueMap,
+			themes: stableThemes,
+			valueMap: stableValueMap,
 			target,
 			disableTransitionOnChange,
 			enableColorScheme,
-			themeColor,
+			themeColor: stableThemeColor,
 		};
 		applyThemeToDom(last);
 		lastAppliedRef.current = last;
@@ -169,7 +185,7 @@ export function ClientThemeProvider<Themes extends string = DefaultTheme>({
 
 			const current = getSnapshot().theme as Themes | "system" | undefined;
 			const newTheme = typeof next === "function" ? next(current) : next;
-			if (!isThemeSelection(newTheme, themes, enableSystem)) return;
+			if (!isThemeSelection(newTheme, stableThemes, enableSystem)) return;
 			const resolved =
 				newTheme === "system" ? (getSnapshot().systemTheme ?? "light") : newTheme;
 
@@ -182,7 +198,7 @@ export function ClientThemeProvider<Themes extends string = DefaultTheme>({
 		},
 		[
 			validForcedTheme,
-			themes,
+			stableThemes,
 			enableSystem,
 			storage,
 			storageKey,
@@ -215,12 +231,12 @@ export function ClientThemeProvider<Themes extends string = DefaultTheme>({
 			last &&
 			last.resolved === resolvedTheme &&
 			last.attribute === attribute &&
-			last.themes === themes &&
-			last.valueMap === valueMap &&
+			last.themes === stableThemes &&
+			last.valueMap === stableValueMap &&
 			last.target === target &&
 			last.disableTransitionOnChange === disableTransitionOnChange &&
 			last.enableColorScheme === enableColorScheme &&
-			last.themeColor === themeColor
+			last.themeColor === stableThemeColor
 		) {
 			return;
 		}
@@ -228,12 +244,12 @@ export function ClientThemeProvider<Themes extends string = DefaultTheme>({
 	}, [
 		resolvedTheme,
 		attribute,
-		themes,
-		valueMap,
+		stableThemes,
+		stableValueMap,
 		target,
 		disableTransitionOnChange,
 		enableColorScheme,
-		themeColor,
+		stableThemeColor,
 	]);
 
 	// oxlint-disable-next-line react-hooks/exhaustive-deps -- effect events are intentionally non-reactive.
@@ -294,10 +310,10 @@ export function ClientThemeProvider<Themes extends string = DefaultTheme>({
 			resolvedTheme,
 			systemTheme,
 			forcedTheme: validForcedTheme,
-			themes,
+			themes: stableThemes,
 			setTheme,
 		}),
-		[validForcedTheme, contextTheme, resolvedTheme, systemTheme, themes, setTheme],
+		[validForcedTheme, contextTheme, resolvedTheme, systemTheme, stableThemes, setTheme],
 	);
 	const ContextProvider = themeContext.Provider;
 

--- a/packages/themes/src/providers/extended-client-provider.tsx
+++ b/packages/themes/src/providers/extended-client-provider.tsx
@@ -8,6 +8,12 @@ import {
 	useRef,
 	useSyncExternalStore,
 } from "react";
+import {
+	holdIfEqual,
+	sameStringList,
+	sameStringRecord,
+	sameThemeColor,
+} from "../core/config-equal.js";
 import { ThemeContext } from "../core/context.js";
 import {
 	type AppliedThemeState,
@@ -95,6 +101,15 @@ export function ExtendedClientThemeProvider<Themes extends string = DefaultTheme
 	const store = storeRef.current;
 	const appliedThemeRef = useRef<AppliedThemeState | undefined>(undefined);
 	const lastAppliedRef = useRef<LastAppliedTheme | null>(null);
+	const themesRef = useRef(themes);
+	themesRef.current = holdIfEqual(themesRef.current, themes, sameStringList);
+	const stableThemes = themesRef.current;
+	const valueMapRef = useRef(valueMap);
+	valueMapRef.current = holdIfEqual(valueMapRef.current, valueMap, sameStringRecord);
+	const stableValueMap = valueMapRef.current;
+	const themeColorRef = useRef(themeColor);
+	themeColorRef.current = holdIfEqual(themeColorRef.current, themeColor, sameThemeColor);
+	const stableThemeColor = themeColorRef.current;
 	const {
 		getSnapshot,
 		setState: setStoreState,
@@ -108,7 +123,8 @@ export function ExtendedClientThemeProvider<Themes extends string = DefaultTheme
 		store.getServerSnapshot,
 	);
 
-	const validForcedTheme = forcedTheme && themes.includes(forcedTheme) ? forcedTheme : undefined;
+	const validForcedTheme =
+		forcedTheme && stableThemes.includes(forcedTheme) ? forcedTheme : undefined;
 	const selectedTheme = validForcedTheme ?? theme;
 	const resolvedTheme = selectedTheme
 		? (resolveSelection(
@@ -127,12 +143,12 @@ export function ExtendedClientThemeProvider<Themes extends string = DefaultTheme
 		const last: LastAppliedTheme = {
 			resolved,
 			attribute,
-			themes,
-			valueMap,
+			themes: stableThemes,
+			valueMap: stableValueMap,
 			target,
 			disableTransitionOnChange,
 			enableColorScheme,
-			themeColor,
+			themeColor: stableThemeColor,
 			themeRoot,
 		};
 		appliedThemeRef.current = applyExtendedThemeToDom({
@@ -209,7 +225,7 @@ export function ExtendedClientThemeProvider<Themes extends string = DefaultTheme
 
 			const current = getSnapshot().theme as Themes | "system" | undefined;
 			const newTheme = typeof next === "function" ? next(current) : next;
-			if (!isThemeSelection(newTheme, themes, enableSystem)) return;
+			if (!isThemeSelection(newTheme, stableThemes, enableSystem)) return;
 			const resolved = resolveSelection(
 				newTheme,
 				getSnapshot().systemTheme,
@@ -226,7 +242,7 @@ export function ExtendedClientThemeProvider<Themes extends string = DefaultTheme
 		},
 		[
 			validForcedTheme,
-			themes,
+			stableThemes,
 			enableSystem,
 			systemThemeMap,
 			storage,
@@ -262,11 +278,12 @@ export function ExtendedClientThemeProvider<Themes extends string = DefaultTheme
 			last &&
 			last.resolved === resolvedTheme &&
 			last.attribute === attribute &&
-			last.themes === themes &&
-			last.valueMap === valueMap &&
+			last.themes === stableThemes &&
+			last.valueMap === stableValueMap &&
 			last.target === target &&
+			last.disableTransitionOnChange === disableTransitionOnChange &&
 			last.enableColorScheme === enableColorScheme &&
-			last.themeColor === themeColor &&
+			last.themeColor === stableThemeColor &&
 			last.themeRoot === themeRoot
 		) {
 			return;
@@ -275,12 +292,12 @@ export function ExtendedClientThemeProvider<Themes extends string = DefaultTheme
 	}, [
 		resolvedTheme,
 		attribute,
-		themes,
-		valueMap,
+		stableThemes,
+		stableValueMap,
 		target,
 		disableTransitionOnChange,
 		enableColorScheme,
-		themeColor,
+		stableThemeColor,
 		themeRoot,
 	]);
 
@@ -367,10 +384,10 @@ export function ExtendedClientThemeProvider<Themes extends string = DefaultTheme
 			resolvedTheme,
 			systemTheme,
 			forcedTheme: validForcedTheme,
-			themes,
+			themes: stableThemes,
 			setTheme: setTheme as ThemeContextValue<string>["setTheme"],
 		}),
-		[validForcedTheme, theme, resolvedTheme, systemTheme, themes, setTheme],
+		[validForcedTheme, theme, resolvedTheme, systemTheme, stableThemes, setTheme],
 	);
 
 	return <ThemeContext.Provider value={contextValue}>{children}</ThemeContext.Provider>;


### PR DESCRIPTION
## Summary
- Client providers currently replace `themes`, `value`, and `themeColor` from new array/object identities even when the contents match, which recreates `ThemeContext` and reruns `setTheme`.
- Hold the previous references when lists, maps, and themeColor are value-equal.
- Also include `disableTransitionOnChange` in the extended skip check.
- Raises next-provider size budgets to match the honest cost and updates `baseline.json`.

## Test plan
- [x] `bun test src/__tests__/config-equal.test.ts src/__tests__/client-provider.test.tsx` from `packages/themes`
- [x] `bun run size:compare` from `packages/themes`
- [ ] CI library + size jobs