### PR TITLE
fix: emit Secure when serializing SameSite=None cookies

### DIFF
--- a/packages/themes/benchmarks/bundle-size-thresholds.json
+++ b/packages/themes/benchmarks/bundle-size-thresholds.json
@@ -61,7 +61,7 @@
 	},
 	"extended-next-provider": {
 		"maxBytes": 12500,
-		"maxGzipBytes": 4650,
+		"maxGzipBytes": 4660,
 		"maxDeltaBytes": 500,
 		"maxDeltaGzipBytes": 250
 	}

--- a/packages/themes/src/__tests__/client-provider.test.tsx
+++ b/packages/themes/src/__tests__/client-provider.test.tsx
@@ -1045,6 +1045,18 @@ describe("serializeCookie", () => {
 		expect(result).toContain("Secure");
 	});
 
+	test("sameSite None implies Secure even when secure is omitted", () => {
+		const result = serializeCookie("theme", "dark", { sameSite: "None" });
+		expect(result).toContain("SameSite=None");
+		expect(result).toContain("Secure");
+	});
+
+	test("sameSite None implies Secure even when secure is false", () => {
+		const result = serializeCookie("theme", "dark", { sameSite: "None", secure: false });
+		expect(result).toContain("SameSite=None");
+		expect(result).toContain("Secure");
+	});
+
 	test("path override", () => {
 		const result = serializeCookie("theme", "dark", { path: "/app" });
 		expect(result).toContain("path=/app");

--- a/packages/themes/src/core/cookie.ts
+++ b/packages/themes/src/core/cookie.ts
@@ -33,7 +33,7 @@ export function serializeCookie(key: string, value: string, options: CookieOptio
 	if (domain) assertCookieAttributeValue(domain, "domain");
 
 	let cookie = `${key}=${encodeURIComponent(value)}; path=${path}; max-age=${maxAge}; SameSite=${sameSite}`;
-	if (secure) cookie += "; Secure";
+	if (sameSite === "None" || secure) cookie += "; Secure";
 	if (domain) cookie += `; domain=${domain}`;
 	return cookie;
 }

--- a/packages/themes/src/core/types.ts
+++ b/packages/themes/src/core/types.ts
@@ -26,7 +26,7 @@ export type CookieOptions = {
 	maxAge?: number;
 	/** SameSite attribute. Defaults to "Lax" */
 	sameSite?: "Strict" | "Lax" | "None";
-	/** Secure flag. Defaults to true on HTTPS */
+	/** Secure flag. Defaults to true on HTTPS. Always set when sameSite is "None". */
 	secure?: boolean;
 	/** Cookie path. Defaults to "/" */
 	path?: string;


### PR DESCRIPTION
## Summary
- Browsers reject `SameSite=None` without `Secure`, so a cross-site cookie with `secure={false}` or omitted `secure` is dropped.
- Serialize `Secure` whenever `sameSite` is `None`, including `secure: false`.
- Documents that override on `CookieOptions.secure`.
- Raises the extended-next-provider gzip ceiling by 10 bytes.

## Test plan
- [x] serializeCookie tests: omitted `secure` and `secure: false` still contain `Secure` when `sameSite` is `None`
- [ ] CI library job