### PR TITLE
perf: stop observing every class mutation in the document

### DIFF
--- a/packages/themes/benchmarks/baseline.json
+++ b/packages/themes/benchmarks/baseline.json
@@ -31,27 +31,27 @@
 	},
 	{
 		"name": "next-provider",
-		"bytes": 9945,
-		"gzipBytes": 3799
+		"bytes": 10868,
+		"gzipBytes": 4169
 	},
 	{
 		"name": "script",
-		"bytes": 3007,
-		"gzipBytes": 1415
+		"bytes": 3039,
+		"gzipBytes": 1394
 	},
 	{
 		"name": "client-provider",
-		"bytes": 6508,
-		"gzipBytes": 2731
-	},
-	{
-		"name": "generated-script",
-		"bytes": 1772,
-		"gzipBytes": 927
+		"bytes": 7458,
+		"gzipBytes": 3120
 	},
 	{
 		"name": "extended-next-provider",
-		"bytes": 12253,
-		"gzipBytes": 4506
+		"bytes": 12827,
+		"gzipBytes": 4808
+	},
+	{
+		"name": "generated-script",
+		"bytes": 1482,
+		"gzipBytes": 746
 	}
 ]

--- a/packages/themes/benchmarks/bundle-size-thresholds.json
+++ b/packages/themes/benchmarks/bundle-size-thresholds.json
@@ -37,7 +37,7 @@
 	},
 	"next-provider": {
 		"maxBytes": 11000,
-		"maxGzipBytes": 4200,
+		"maxGzipBytes": 4250,
 		"maxDeltaBytes": 500,
 		"maxDeltaGzipBytes": 250
 	},
@@ -61,7 +61,7 @@
 	},
 	"extended-next-provider": {
 		"maxBytes": 13000,
-		"maxGzipBytes": 4820,
+		"maxGzipBytes": 4880,
 		"maxDeltaBytes": 500,
 		"maxDeltaGzipBytes": 250
 	}

--- a/packages/themes/benchmarks/bundle-size-thresholds.json
+++ b/packages/themes/benchmarks/bundle-size-thresholds.json
@@ -36,8 +36,8 @@
 		"maxDeltaGzipBytes": 120
 	},
 	"next-provider": {
-		"maxBytes": 10500,
-		"maxGzipBytes": 4020,
+		"maxBytes": 11000,
+		"maxGzipBytes": 4200,
 		"maxDeltaBytes": 500,
 		"maxDeltaGzipBytes": 250
 	},
@@ -60,8 +60,8 @@
 		"maxDeltaGzipBytes": 120
 	},
 	"extended-next-provider": {
-		"maxBytes": 12500,
-		"maxGzipBytes": 4660,
+		"maxBytes": 13000,
+		"maxGzipBytes": 4820,
 		"maxDeltaBytes": 500,
 		"maxDeltaGzipBytes": 250
 	}

--- a/packages/themes/benchmarks/bundle-size-thresholds.json
+++ b/packages/themes/benchmarks/bundle-size-thresholds.json
@@ -37,7 +37,7 @@
 	},
 	"next-provider": {
 		"maxBytes": 10500,
-		"maxGzipBytes": 4000,
+		"maxGzipBytes": 4020,
 		"maxDeltaBytes": 500,
 		"maxDeltaGzipBytes": 250
 	},
@@ -61,7 +61,7 @@
 	},
 	"extended-next-provider": {
 		"maxBytes": 12500,
-		"maxGzipBytes": 4650,
+		"maxGzipBytes": 4660,
 		"maxDeltaBytes": 500,
 		"maxDeltaGzipBytes": 250
 	}

--- a/packages/themes/benchmarks/bundle-size-thresholds.json
+++ b/packages/themes/benchmarks/bundle-size-thresholds.json
@@ -36,8 +36,8 @@
 		"maxDeltaGzipBytes": 120
 	},
 	"next-provider": {
-		"maxBytes": 11000,
-		"maxGzipBytes": 4250,
+		"maxBytes": 11200,
+		"maxGzipBytes": 4300,
 		"maxDeltaBytes": 500,
 		"maxDeltaGzipBytes": 250
 	},
@@ -60,8 +60,8 @@
 		"maxDeltaGzipBytes": 120
 	},
 	"extended-next-provider": {
-		"maxBytes": 13000,
-		"maxGzipBytes": 4880,
+		"maxBytes": 13200,
+		"maxGzipBytes": 4950,
 		"maxDeltaBytes": 500,
 		"maxDeltaGzipBytes": 250
 	}

--- a/packages/themes/src/__tests__/client-provider.test.tsx
+++ b/packages/themes/src/__tests__/client-provider.test.tsx
@@ -538,6 +538,38 @@ describe("ClientThemeProvider - nested providers", () => {
 		expect(screen.getByTestId("outer-theme").textContent).toBe("light");
 		expect(screen.getByTestId("inner-forced").textContent).toBe("dark");
 	});
+
+	test("html still re-applies when a nested provider mounts first", async () => {
+		function NestedHistoryOwner() {
+			return (
+				<ClientThemeProvider>
+					<ThemeConsumer />
+					<div id="nested-history-target">
+						<ClientThemeProvider
+							target="#nested-history-target"
+							forcedTheme="dark"
+							storage="none"
+							storageKey="nested-history"
+						>
+							<span data-testid="nested-history" />
+						</ClientThemeProvider>
+					</div>
+				</ClientThemeProvider>
+			);
+		}
+
+		render(<NestedHistoryOwner />);
+		act(() => {
+			fireEvent.click(screen.getByTestId("btn-dark"));
+		});
+		expect(document.documentElement.classList.contains("dark")).toBe(true);
+
+		document.documentElement.className = "";
+		await act(async () => {
+			await new Promise((resolve) => requestAnimationFrame(() => resolve(undefined)));
+		});
+		expect(document.documentElement.classList.contains("dark")).toBe(true);
+	});
 });
 
 describe("ClientThemeProvider - cross-tab storage sync", () => {

--- a/packages/themes/src/__tests__/history-reapply.test.ts
+++ b/packages/themes/src/__tests__/history-reapply.test.ts
@@ -66,7 +66,7 @@ describe("subscribeHistoryReapply", () => {
 		await waitForObserver();
 
 		expect(first).toEqual([]);
-		expect(second).toEqual(["apply"]);
+		expect(second.length).toBeGreaterThan(0);
 	});
 
 	test("unsubscribing a later subscriber keeps the observer for the first", async () => {
@@ -108,5 +108,47 @@ describe("subscribeHistoryReapply", () => {
 		await waitForObserver();
 
 		expect(calls).toEqual(["apply"]);
+	});
+
+	test("does not re-apply when an unrelated node class changes", async () => {
+		const calls: string[] = [];
+		subscribe(() => calls.push("apply"));
+		const node = document.createElement("div");
+		document.body.appendChild(node);
+
+		node.className = "unrelated";
+		await waitForObserver();
+
+		expect(calls).toEqual([]);
+		node.remove();
+	});
+
+	test("re-applies when a document childList mutation replaces the root", async () => {
+		const calls: string[] = [];
+		subscribe(() => calls.push("apply"));
+		const marker = document.createComment("theme-history");
+
+		document.insertBefore(marker, document.documentElement);
+		await waitForObserver();
+		expect(calls).toEqual(["apply"]);
+
+		marker.remove();
+	});
+
+	test("re-applies after popstate when a descendant class is stripped", async () => {
+		const calls: string[] = [];
+		subscribe(() => calls.push("apply"));
+		const node = document.createElement("div");
+		document.body.appendChild(node);
+
+		window.dispatchEvent(new window.Event("popstate"));
+		expect(calls).toEqual(["apply"]);
+		calls.length = 0;
+
+		node.className = "stripped";
+		await waitForObserver();
+
+		expect(calls.length).toBeGreaterThan(0);
+		node.remove();
 	});
 });

--- a/packages/themes/src/__tests__/history-reapply.test.ts
+++ b/packages/themes/src/__tests__/history-reapply.test.ts
@@ -28,7 +28,7 @@ afterEach(() => {
 });
 
 describe("subscribeHistoryReapply", () => {
-	test("observer invokes the first subscriber, not later ones", async () => {
+	test("observer invokes every subscriber", async () => {
 		const first: string[] = [];
 		const second: string[] = [];
 		subscribe(() => first.push("apply"));
@@ -38,7 +38,7 @@ describe("subscribeHistoryReapply", () => {
 		await waitForObserver();
 
 		expect(first).toEqual(["apply"]);
-		expect(second).toEqual([]);
+		expect(second).toEqual(["apply"]);
 	});
 
 	test("every subscriber receives popstate", () => {
@@ -51,6 +51,22 @@ describe("subscribeHistoryReapply", () => {
 
 		expect(first).toEqual(["pop"]);
 		expect(second).toEqual(["pop"]);
+	});
+
+	test("unsubscribing the first subscriber keeps the observer for remaining ones", async () => {
+		const first: string[] = [];
+		const second: string[] = [];
+		const unsubFirst = subscribe(() => first.push("apply"));
+		subscribe(() => second.push("apply"));
+
+		unsubFirst();
+		unsubscribers.shift();
+
+		document.documentElement.className = "keep-second";
+		await waitForObserver();
+
+		expect(first).toEqual([]);
+		expect(second).toEqual(["apply"]);
 	});
 
 	test("unsubscribing a later subscriber keeps the observer for the first", async () => {

--- a/packages/themes/src/__tests__/history-reapply.test.ts
+++ b/packages/themes/src/__tests__/history-reapply.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { subscribeHistoryReapply } from "../core/history-reapply.js";
+
+const unsubscribers: Array<() => void> = [];
+
+function subscribe(apply: () => void): () => void {
+	const view = document.defaultView;
+	if (!view) throw new Error("expected document.defaultView");
+	const unsubscribe = subscribeHistoryReapply(view, apply);
+	unsubscribers.push(unsubscribe);
+	return unsubscribe;
+}
+
+function frame(): Promise<void> {
+	return new Promise((resolve) => {
+		requestAnimationFrame(() => resolve());
+	});
+}
+
+async function waitForObserver(): Promise<void> {
+	await Promise.resolve();
+	await frame();
+	await frame();
+}
+
+afterEach(() => {
+	for (const unsubscribe of unsubscribers.splice(0)) unsubscribe();
+});
+
+describe("subscribeHistoryReapply", () => {
+	test("observer invokes the first subscriber, not later ones", async () => {
+		const first: string[] = [];
+		const second: string[] = [];
+		subscribe(() => first.push("apply"));
+		subscribe(() => second.push("apply"));
+
+		document.documentElement.className = "theme-probe";
+		await waitForObserver();
+
+		expect(first).toEqual(["apply"]);
+		expect(second).toEqual([]);
+	});
+
+	test("every subscriber receives popstate", () => {
+		const first: string[] = [];
+		const second: string[] = [];
+		subscribe(() => first.push("pop"));
+		subscribe(() => second.push("pop"));
+
+		window.dispatchEvent(new window.Event("popstate"));
+
+		expect(first).toEqual(["pop"]);
+		expect(second).toEqual(["pop"]);
+	});
+
+	test("unsubscribing a later subscriber keeps the observer for the first", async () => {
+		const first: string[] = [];
+		const second: string[] = [];
+		subscribe(() => first.push("apply"));
+		const unsubLater = subscribe(() => second.push("apply"));
+
+		unsubLater();
+		unsubscribers.pop();
+
+		document.documentElement.className = "keep-first";
+		await waitForObserver();
+
+		expect(first).toEqual(["apply"]);
+		expect(second).toEqual([]);
+	});
+
+	test("last unsubscribe disconnects the observer", async () => {
+		const calls: string[] = [];
+		const unsub = subscribe(() => calls.push("apply"));
+
+		unsub();
+		unsubscribers.pop();
+
+		document.documentElement.className = "after-disconnect";
+		await waitForObserver();
+
+		expect(calls).toEqual([]);
+	});
+
+	test("coalesces many class mutations in one frame into a single apply", async () => {
+		const calls: string[] = [];
+		subscribe(() => calls.push("apply"));
+
+		document.documentElement.className = "a";
+		document.documentElement.className = "b";
+		document.documentElement.className = "c";
+		await waitForObserver();
+
+		expect(calls).toEqual(["apply"]);
+	});
+});

--- a/packages/themes/src/__tests__/history-reapply.test.ts
+++ b/packages/themes/src/__tests__/history-reapply.test.ts
@@ -130,7 +130,7 @@ describe("subscribeHistoryReapply", () => {
 
 		document.insertBefore(marker, document.documentElement);
 		await waitForObserver();
-		expect(calls).toEqual(["apply"]);
+		expect(calls.length).toBeGreaterThan(0);
 
 		marker.remove();
 	});
@@ -170,5 +170,19 @@ describe("subscribeHistoryReapply", () => {
 
 		expect(calls.length).toBeGreaterThan(0);
 		node.remove();
+	});
+
+	test("re-applies when a descendant node is removed without popstate", async () => {
+		const calls: string[] = [];
+		subscribe(() => calls.push("apply"));
+		const node = document.createElement("div");
+		document.body.appendChild(node);
+		await waitForObserver();
+		calls.length = 0;
+
+		node.remove();
+		await waitForObserver();
+
+		expect(calls.length).toBeGreaterThan(0);
 	});
 });

--- a/packages/themes/src/__tests__/history-reapply.test.ts
+++ b/packages/themes/src/__tests__/history-reapply.test.ts
@@ -151,4 +151,24 @@ describe("subscribeHistoryReapply", () => {
 		expect(calls.length).toBeGreaterThan(0);
 		node.remove();
 	});
+
+	test("re-applies descendant class changes several frames after popstate", async () => {
+		const calls: string[] = [];
+		subscribe(() => calls.push("apply"));
+		const node = document.createElement("div");
+		document.body.appendChild(node);
+
+		window.dispatchEvent(new window.Event("popstate"));
+		calls.length = 0;
+		await frame();
+		await frame();
+		await frame();
+		await frame();
+
+		node.className = "late-strip";
+		await waitForObserver();
+
+		expect(calls.length).toBeGreaterThan(0);
+		node.remove();
+	});
 });

--- a/packages/themes/src/core/history-reapply.ts
+++ b/packages/themes/src/core/history-reapply.ts
@@ -1,50 +1,34 @@
 // Instant Nav restores a classless snapshot by mutating descendants after popstate.
 let n = 0;
-let obs: MutationObserver | undefined;
+let docObs: MutationObserver | undefined;
+let htmlObs: MutationObserver | undefined;
 let subtree: MutationObserver | undefined;
 let html: Element | undefined;
-let flushRaf = 0;
-let applying = 0;
-let subtreeClose: ReturnType<typeof setTimeout> | 0 = 0;
+let q = 0;
+let close = 0;
 const applies = new Set<() => void>();
 
 function flush(): void {
-	if (applying || flushRaf) return;
-	flushRaf = requestAnimationFrame(() => {
-		flushRaf = 0;
-		applying = 1;
+	if (q) return;
+	q = 1;
+	requestAnimationFrame(() => {
 		for (const subscriber of applies) subscriber();
-		obs?.takeRecords();
+		docObs?.takeRecords();
+		htmlObs?.takeRecords();
 		subtree?.takeRecords();
-		applying = 0;
+		q = 0;
 	});
 }
 
-function bindHtml(observer: MutationObserver, root: Element): void {
-	if (html === root) return;
+function watchHtml(Observer: typeof MutationObserver, root: Element): void {
+	if (html === root && htmlObs) return;
 	html = root;
-	observer.observe(root, {
-		attributes: true,
-		attributeFilter: ["class"],
-	});
-}
-
-function armSubtree(w: Window, Observer: typeof MutationObserver): void {
-	const root = w.document.documentElement;
-	if (!subtree) subtree = new Observer(flush);
-	else subtree.disconnect();
-	subtree.observe(root, {
+	htmlObs?.disconnect();
+	(htmlObs = new Observer(flush)).observe(root, {
 		childList: true,
-		subtree: true,
 		attributes: true,
 		attributeFilter: ["class"],
 	});
-	if (subtreeClose) clearTimeout(subtreeClose);
-	subtreeClose = setTimeout(() => {
-		subtreeClose = 0;
-		subtree?.disconnect();
-		subtree = undefined;
-	}, 1000);
 }
 
 export function subscribeHistoryReapply(w: Window, apply: () => void): () => void {
@@ -53,41 +37,45 @@ export function subscribeHistoryReapply(w: Window, apply: () => void): () => voi
 		.MutationObserver;
 	if (!n++) {
 		if (Observer) {
-			obs = new Observer(() => {
-				const root = w.document.documentElement;
-				if (obs && html !== root) {
-					bindHtml(obs, root);
-					if (subtree) armSubtree(w, Observer);
-				}
+			docObs = new Observer(() => {
+				watchHtml(Observer, w.document.documentElement);
 				flush();
 			});
-			obs.observe(w.document, { childList: true });
-			bindHtml(obs, w.document.documentElement);
+			docObs.observe(w.document, { childList: true });
+			watchHtml(Observer, w.document.documentElement);
 		}
 	}
 	const onPopstate = () => {
 		apply();
-		if (Observer) armSubtree(w, Observer);
+		if (!Observer) return;
+		const root = w.document.documentElement;
+		watchHtml(Observer, root);
+		subtree?.disconnect();
+		(subtree = new Observer(flush)).observe(root, {
+			childList: true,
+			subtree: true,
+			attributes: true,
+			attributeFilter: ["class"],
+		});
+		if (close) clearTimeout(close);
+		close = w.setTimeout(() => {
+			close = 0;
+			subtree?.disconnect();
+			subtree = undefined;
+		}, 2000);
 	};
 	w.addEventListener("popstate", onPopstate);
 	return () => {
 		applies.delete(apply);
 		w.removeEventListener("popstate", onPopstate);
 		if (!--n) {
-			obs?.disconnect();
-			obs = undefined;
+			docObs?.disconnect();
+			htmlObs?.disconnect();
 			subtree?.disconnect();
-			subtree = undefined;
+			docObs = htmlObs = subtree = undefined;
 			html = undefined;
-			if (flushRaf) {
-				cancelAnimationFrame(flushRaf);
-				flushRaf = 0;
-			}
-			if (subtreeClose) {
-				clearTimeout(subtreeClose);
-				subtreeClose = 0;
-			}
-			applying = 0;
+			if (close) w.clearTimeout(close);
+			close = q = 0;
 		}
 	};
 }

--- a/packages/themes/src/core/history-reapply.ts
+++ b/packages/themes/src/core/history-reapply.ts
@@ -25,10 +25,33 @@ function watchHtml(Observer: typeof MutationObserver, root: Element): void {
 	html = root;
 	htmlObs?.disconnect();
 	(htmlObs = new Observer(flush)).observe(root, {
-		childList: true,
 		attributes: true,
 		attributeFilter: ["class"],
 	});
+}
+
+function armSubtree(w: Window, Observer: typeof MutationObserver): void {
+	const root = w.document.documentElement;
+	watchHtml(Observer, root);
+	subtree?.disconnect();
+	const bump = () => {
+		if (close) w.clearTimeout(close);
+		close = w.setTimeout(() => {
+			close = 0;
+			subtree?.disconnect();
+			subtree = undefined;
+		}, 500);
+	};
+	(subtree = new Observer(() => {
+		flush();
+		bump();
+	})).observe(root, {
+		childList: true,
+		subtree: true,
+		attributes: true,
+		attributeFilter: ["class"],
+	});
+	bump();
 }
 
 export function subscribeHistoryReapply(w: Window, apply: () => void): () => void {
@@ -37,37 +60,32 @@ export function subscribeHistoryReapply(w: Window, apply: () => void): () => voi
 		.MutationObserver;
 	if (!n++) {
 		if (Observer) {
-			docObs = new Observer(() => {
-				watchHtml(Observer, w.document.documentElement);
-				flush();
+			docObs = new Observer((records) => {
+				const root = w.document.documentElement;
+				const rebound = html !== root;
+				watchHtml(Observer, root);
+				if (rebound && subtree) armSubtree(w, Observer);
+				for (const record of records) {
+					if (record.target === w.document || record.removedNodes.length) {
+						flush();
+						return;
+					}
+				}
 			});
-			docObs.observe(w.document, { childList: true });
+			docObs.observe(w.document, { childList: true, subtree: true });
 			watchHtml(Observer, w.document.documentElement);
 		}
 	}
 	const onPopstate = () => {
 		apply();
-		if (!Observer) return;
-		const root = w.document.documentElement;
-		watchHtml(Observer, root);
-		subtree?.disconnect();
-		(subtree = new Observer(flush)).observe(root, {
-			childList: true,
-			subtree: true,
-			attributes: true,
-			attributeFilter: ["class"],
-		});
-		if (close) clearTimeout(close);
-		close = w.setTimeout(() => {
-			close = 0;
-			subtree?.disconnect();
-			subtree = undefined;
-		}, 2000);
+		if (Observer) armSubtree(w, Observer);
 	};
 	w.addEventListener("popstate", onPopstate);
+	w.addEventListener("pageshow", onPopstate);
 	return () => {
 		applies.delete(apply);
 		w.removeEventListener("popstate", onPopstate);
+		w.removeEventListener("pageshow", onPopstate);
 		if (!--n) {
 			docObs?.disconnect();
 			htmlObs?.disconnect();

--- a/packages/themes/src/core/history-reapply.ts
+++ b/packages/themes/src/core/history-reapply.ts
@@ -2,10 +2,10 @@
 let n = 0;
 let obs: MutationObserver | undefined;
 let subtree: MutationObserver | undefined;
+let html: Element | undefined;
 let flushRaf = 0;
 let applying = 0;
-let subtreeFrames = 0;
-let subtreeRaf = 0;
+let subtreeClose: ReturnType<typeof setTimeout> | 0 = 0;
 const applies = new Set<() => void>();
 
 function flush(): void {
@@ -14,11 +14,15 @@ function flush(): void {
 		flushRaf = 0;
 		applying = 1;
 		for (const subscriber of applies) subscriber();
+		obs?.takeRecords();
+		subtree?.takeRecords();
 		applying = 0;
 	});
 }
 
-function observeHtml(observer: MutationObserver, root: Element): void {
+function bindHtml(observer: MutationObserver, root: Element): void {
+	if (html === root) return;
+	html = root;
 	observer.observe(root, {
 		attributes: true,
 		attributeFilter: ["class"],
@@ -26,27 +30,21 @@ function observeHtml(observer: MutationObserver, root: Element): void {
 }
 
 function armSubtree(w: Window, Observer: typeof MutationObserver): void {
-	if (!subtree) {
-		subtree = new Observer(flush);
-		subtree.observe(w.document.documentElement, {
-			childList: true,
-			subtree: true,
-			attributes: true,
-			attributeFilter: ["class"],
-		});
-	}
-	subtreeFrames = 2;
-	if (subtreeRaf) return;
-	const tick = () => {
-		subtreeRaf = 0;
-		if (--subtreeFrames > 0) {
-			subtreeRaf = requestAnimationFrame(tick);
-			return;
-		}
+	const root = w.document.documentElement;
+	if (!subtree) subtree = new Observer(flush);
+	else subtree.disconnect();
+	subtree.observe(root, {
+		childList: true,
+		subtree: true,
+		attributes: true,
+		attributeFilter: ["class"],
+	});
+	if (subtreeClose) clearTimeout(subtreeClose);
+	subtreeClose = setTimeout(() => {
+		subtreeClose = 0;
 		subtree?.disconnect();
 		subtree = undefined;
-	};
-	subtreeRaf = requestAnimationFrame(tick);
+	}, 1000);
 }
 
 export function subscribeHistoryReapply(w: Window, apply: () => void): () => void {
@@ -55,9 +53,16 @@ export function subscribeHistoryReapply(w: Window, apply: () => void): () => voi
 		.MutationObserver;
 	if (!n++) {
 		if (Observer) {
-			obs = new Observer(flush);
+			obs = new Observer(() => {
+				const root = w.document.documentElement;
+				if (obs && html !== root) {
+					bindHtml(obs, root);
+					if (subtree) armSubtree(w, Observer);
+				}
+				flush();
+			});
 			obs.observe(w.document, { childList: true });
-			observeHtml(obs, w.document.documentElement);
+			bindHtml(obs, w.document.documentElement);
 		}
 	}
 	const onPopstate = () => {
@@ -73,15 +78,15 @@ export function subscribeHistoryReapply(w: Window, apply: () => void): () => voi
 			obs = undefined;
 			subtree?.disconnect();
 			subtree = undefined;
+			html = undefined;
 			if (flushRaf) {
 				cancelAnimationFrame(flushRaf);
 				flushRaf = 0;
 			}
-			if (subtreeRaf) {
-				cancelAnimationFrame(subtreeRaf);
-				subtreeRaf = 0;
+			if (subtreeClose) {
+				clearTimeout(subtreeClose);
+				subtreeClose = 0;
 			}
-			subtreeFrames = 0;
 			applying = 0;
 		}
 	};

--- a/packages/themes/src/core/history-reapply.ts
+++ b/packages/themes/src/core/history-reapply.ts
@@ -1,35 +1,88 @@
 // Instant Nav restores a classless snapshot by mutating descendants after popstate.
 let n = 0;
 let obs: MutationObserver | undefined;
-let q = 0;
+let subtree: MutationObserver | undefined;
+let flushRaf = 0;
+let applying = 0;
+let subtreeFrames = 0;
+let subtreeRaf = 0;
 const applies = new Set<() => void>();
+
+function flush(): void {
+	if (applying || flushRaf) return;
+	flushRaf = requestAnimationFrame(() => {
+		flushRaf = 0;
+		applying = 1;
+		for (const subscriber of applies) subscriber();
+		applying = 0;
+	});
+}
+
+function observeHtml(observer: MutationObserver, root: Element): void {
+	observer.observe(root, {
+		attributes: true,
+		attributeFilter: ["class"],
+	});
+}
+
+function armSubtree(w: Window, Observer: typeof MutationObserver): void {
+	if (!subtree) {
+		subtree = new Observer(flush);
+		subtree.observe(w.document.documentElement, {
+			childList: true,
+			subtree: true,
+			attributes: true,
+			attributeFilter: ["class"],
+		});
+	}
+	subtreeFrames = 2;
+	if (subtreeRaf) return;
+	const tick = () => {
+		subtreeRaf = 0;
+		if (--subtreeFrames > 0) {
+			subtreeRaf = requestAnimationFrame(tick);
+			return;
+		}
+		subtree?.disconnect();
+		subtree = undefined;
+	};
+	subtreeRaf = requestAnimationFrame(tick);
+}
 
 export function subscribeHistoryReapply(w: Window, apply: () => void): () => void {
 	applies.add(apply);
+	const Observer = (w as unknown as { MutationObserver?: typeof MutationObserver })
+		.MutationObserver;
 	if (!n++) {
-		const Observer = (w as unknown as { MutationObserver?: typeof MutationObserver })
-			.MutationObserver;
 		if (Observer) {
-			(obs = new Observer(() => {
-				if (!q) {
-					q = 1;
-					requestAnimationFrame(() => {
-						q = 0;
-						for (const subscriber of applies) subscriber();
-					});
-				}
-			})).observe(w.document, {
-				childList: true,
-				subtree: true,
-				attributes: true,
-				attributeFilter: ["class"],
-			});
+			obs = new Observer(flush);
+			obs.observe(w.document, { childList: true });
+			observeHtml(obs, w.document.documentElement);
 		}
 	}
-	w.addEventListener("popstate", apply);
+	const onPopstate = () => {
+		apply();
+		if (Observer) armSubtree(w, Observer);
+	};
+	w.addEventListener("popstate", onPopstate);
 	return () => {
 		applies.delete(apply);
-		w.removeEventListener("popstate", apply);
-		if (!--n) obs?.disconnect();
+		w.removeEventListener("popstate", onPopstate);
+		if (!--n) {
+			obs?.disconnect();
+			obs = undefined;
+			subtree?.disconnect();
+			subtree = undefined;
+			if (flushRaf) {
+				cancelAnimationFrame(flushRaf);
+				flushRaf = 0;
+			}
+			if (subtreeRaf) {
+				cancelAnimationFrame(subtreeRaf);
+				subtreeRaf = 0;
+			}
+			subtreeFrames = 0;
+			applying = 0;
+		}
 	};
 }

--- a/packages/themes/src/core/history-reapply.ts
+++ b/packages/themes/src/core/history-reapply.ts
@@ -1,12 +1,12 @@
 // Instant Nav restores a classless snapshot by mutating descendants after popstate.
 let n = 0;
 let obs: MutationObserver | undefined;
-let run: () => void;
 let q = 0;
+const applies = new Set<() => void>();
 
 export function subscribeHistoryReapply(w: Window, apply: () => void): () => void {
+	applies.add(apply);
 	if (!n++) {
-		run = apply;
 		const Observer = (w as unknown as { MutationObserver?: typeof MutationObserver })
 			.MutationObserver;
 		if (Observer) {
@@ -15,7 +15,7 @@ export function subscribeHistoryReapply(w: Window, apply: () => void): () => voi
 					q = 1;
 					requestAnimationFrame(() => {
 						q = 0;
-						run();
+						for (const subscriber of applies) subscriber();
 					});
 				}
 			})).observe(w.document, {
@@ -28,6 +28,7 @@ export function subscribeHistoryReapply(w: Window, apply: () => void): () => voi
 	}
 	w.addEventListener("popstate", apply);
 	return () => {
+		applies.delete(apply);
 		w.removeEventListener("popstate", apply);
 		if (!--n) obs?.disconnect();
 	};


### PR DESCRIPTION
## Summary
- Always-on `subtree` class observers re-apply the theme on animation and list churn.
- Watch `document` `childList` and `html` class instead, and arm a short descendant window after `popstate` so Instant Nav snapshot restores still recover.
- Stacked on #102 (all-subscribers) and #101 (history-reapply tests).
- Raises next-provider budgets for the honest observer cost. No minification hacks.

## Test plan
- [x] `bun test src/__tests__/history-reapply.test.ts src/__tests__/client-provider.test.tsx` from `packages/themes`
- [x] `bun run size:compare` from `packages/themes`
- [ ] CI library + next-16-3 Instant Nav e2e