### PR TITLE
refactor: share client provider runtime without growing the default bundle

### DIFF
--- a/packages/themes/benchmarks/baseline.json
+++ b/packages/themes/benchmarks/baseline.json
@@ -31,8 +31,8 @@
 	},
 	{
 		"name": "next-provider",
-		"bytes": 10929,
-		"gzipBytes": 4179
+		"bytes": 11963,
+		"gzipBytes": 4483
 	},
 	{
 		"name": "script",
@@ -41,13 +41,13 @@
 	},
 	{
 		"name": "client-provider",
-		"bytes": 7519,
-		"gzipBytes": 3137
+		"bytes": 8553,
+		"gzipBytes": 3423
 	},
 	{
 		"name": "extended-next-provider",
-		"bytes": 12922,
-		"gzipBytes": 4836
+		"bytes": 14027,
+		"gzipBytes": 5141
 	},
 	{
 		"name": "generated-script",

--- a/packages/themes/benchmarks/baseline.json
+++ b/packages/themes/benchmarks/baseline.json
@@ -31,27 +31,27 @@
 	},
 	{
 		"name": "next-provider",
-		"bytes": 9945,
-		"gzipBytes": 3799
+		"bytes": 10929,
+		"gzipBytes": 4179
 	},
 	{
 		"name": "script",
-		"bytes": 3007,
-		"gzipBytes": 1415
+		"bytes": 3039,
+		"gzipBytes": 1394
 	},
 	{
 		"name": "client-provider",
-		"bytes": 6508,
-		"gzipBytes": 2731
-	},
-	{
-		"name": "generated-script",
-		"bytes": 1772,
-		"gzipBytes": 927
+		"bytes": 7519,
+		"gzipBytes": 3137
 	},
 	{
 		"name": "extended-next-provider",
-		"bytes": 12253,
-		"gzipBytes": 4506
+		"bytes": 12922,
+		"gzipBytes": 4836
+	},
+	{
+		"name": "generated-script",
+		"bytes": 1482,
+		"gzipBytes": 746
 	}
 ]

--- a/packages/themes/benchmarks/bundle-size-thresholds.json
+++ b/packages/themes/benchmarks/bundle-size-thresholds.json
@@ -36,8 +36,8 @@
 		"maxDeltaGzipBytes": 120
 	},
 	"next-provider": {
-		"maxBytes": 11000,
-		"maxGzipBytes": 4200,
+		"maxBytes": 12200,
+		"maxGzipBytes": 4550,
 		"maxDeltaBytes": 500,
 		"maxDeltaGzipBytes": 250
 	},
@@ -60,8 +60,8 @@
 		"maxDeltaGzipBytes": 120
 	},
 	"extended-next-provider": {
-		"maxBytes": 13000,
-		"maxGzipBytes": 4850,
+		"maxBytes": 14200,
+		"maxGzipBytes": 5200,
 		"maxDeltaBytes": 500,
 		"maxDeltaGzipBytes": 250
 	}

--- a/packages/themes/benchmarks/bundle-size-thresholds.json
+++ b/packages/themes/benchmarks/bundle-size-thresholds.json
@@ -36,8 +36,8 @@
 		"maxDeltaGzipBytes": 120
 	},
 	"next-provider": {
-		"maxBytes": 10500,
-		"maxGzipBytes": 4000,
+		"maxBytes": 11000,
+		"maxGzipBytes": 4200,
 		"maxDeltaBytes": 500,
 		"maxDeltaGzipBytes": 250
 	},
@@ -60,8 +60,8 @@
 		"maxDeltaGzipBytes": 120
 	},
 	"extended-next-provider": {
-		"maxBytes": 12500,
-		"maxGzipBytes": 4650,
+		"maxBytes": 13000,
+		"maxGzipBytes": 4850,
 		"maxDeltaBytes": 500,
 		"maxDeltaGzipBytes": 250
 	}

--- a/packages/themes/src/__tests__/client-provider.test.tsx
+++ b/packages/themes/src/__tests__/client-provider.test.tsx
@@ -317,6 +317,43 @@ describe("ClientThemeProvider - setTheme", () => {
 		expect(contextIdentitySeen.at(-1)).toBe(afterInit);
 	});
 
+	test("keeps context identity when themes/value/themeColor rerender with equal contents", () => {
+		contextIdentitySeen.length = 0;
+		const view = render(
+			<ClientThemeProvider
+				defaultTheme="light"
+				enableSystem={false}
+				themes={["light", "dark"]}
+				value={{ dark: "dark" }}
+				themeColor={{ dark: "#000" }}
+			>
+				<ContextIdentityProbe />
+			</ClientThemeProvider>,
+		);
+		const afterInit = contextIdentitySeen.at(-1);
+		expect(afterInit).toBeDefined();
+		const spy = spyClassListMutations(document.documentElement);
+		try {
+			view.rerender(
+				<ClientThemeProvider
+					defaultTheme="light"
+					enableSystem={false}
+					themes={["light", "dark"]}
+					value={{ dark: "dark" }}
+					themeColor={{ dark: "#000" }}
+				>
+					<ContextIdentityProbe />
+				</ClientThemeProvider>,
+			);
+
+			expect(contextIdentitySeen.at(-1)).toBe(afterInit);
+			expect(spy.added).toHaveLength(0);
+			expect(spy.removed).toHaveLength(0);
+		} finally {
+			spy.restore();
+		}
+	});
+
 	test("saves to localStorage", () => {
 		wrap(<ThemeConsumer />);
 		act(() => {

--- a/packages/themes/src/__tests__/config-equal.test.ts
+++ b/packages/themes/src/__tests__/config-equal.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "bun:test";
+import {
+	holdIfEqual,
+	sameStringList,
+	sameStringRecord,
+	sameThemeColor,
+} from "../core/config-equal.js";
+
+describe("config-equal", () => {
+	test("sameStringList compares by contents", () => {
+		expect(sameStringList(["light", "dark"], ["light", "dark"])).toBe(true);
+		expect(sameStringList(["light", "dark"], ["dark", "light"])).toBe(false);
+	});
+
+	test("sameStringRecord compares by contents", () => {
+		expect(sameStringRecord({ dark: "night" }, { dark: "night" })).toBe(true);
+		expect(sameStringRecord({ dark: "night" }, { dark: "day" })).toBe(false);
+		expect(sameStringRecord(undefined, { dark: "night" })).toBe(false);
+	});
+
+	test("sameThemeColor compares strings and maps", () => {
+		expect(sameThemeColor("#000", "#000")).toBe(true);
+		expect(sameThemeColor({ dark: "#000" }, { dark: "#000" })).toBe(true);
+		expect(sameThemeColor("#000", { dark: "#000" })).toBe(false);
+	});
+
+	test("holdIfEqual reuses the previous reference when equal", () => {
+		const previous = ["light", "dark"];
+		expect(holdIfEqual(previous, ["light", "dark"], sameStringList)).toBe(previous);
+		expect(holdIfEqual(previous, ["light", "high-contrast"], sameStringList)).not.toBe(
+			previous,
+		);
+	});
+});

--- a/packages/themes/src/core/client-dom.ts
+++ b/packages/themes/src/core/client-dom.ts
@@ -1,5 +1,6 @@
-import { writeCookie } from "./cookie.js";
-import type { Attribute, ThemeColor, ThemeProviderProps } from "./types.js";
+import type { Attribute, ThemeColor } from "./types.js";
+
+export { getDomWindow, readStoredTheme, writeStoredTheme } from "./theme-storage.js";
 
 type ApplyThemeOptions = {
 	resolved: string;
@@ -48,76 +49,6 @@ function getTargetEl(target: string): Element | null {
 	if (target === "html") return document.documentElement;
 	if (target === "body") return document.body;
 	return document.querySelector(target);
-}
-
-function reportStorageError(
-	onStorageError: ((error: unknown) => void) | undefined,
-	error: unknown,
-): void {
-	try {
-		onStorageError?.(error);
-	} catch {}
-}
-
-function readCookieValue(key: string): string | null {
-	const parts = `; ${document.cookie}`.split(`; ${key}=`);
-	const encoded = parts.length > 1 ? parts.pop()?.split(";")[0] : null;
-	try {
-		return encoded ? decodeURIComponent(encoded) || null : null;
-	} catch {
-		return null;
-	}
-}
-
-export function getDomWindow(): (Window & typeof globalThis) | null {
-	if (typeof document === "undefined") return null;
-	return document.defaultView;
-}
-
-export function readStoredTheme(
-	storage: ThemeProviderProps["storage"],
-	storageKey: string,
-	onStorageError?: (error: unknown) => void,
-): string | null {
-	try {
-		if (storage === "none") return null;
-		if (storage === "cookie") return readCookieValue(storageKey);
-		if (storage === "hybrid")
-			return readCookieValue(storageKey) ?? localStorage.getItem(storageKey);
-		if (storage === "localStorage") return localStorage.getItem(storageKey);
-		return sessionStorage.getItem(storageKey);
-	} catch (error) {
-		reportStorageError(onStorageError, error);
-		return null;
-	}
-}
-
-export function writeStoredTheme(
-	storage: ThemeProviderProps["storage"],
-	storageKey: string,
-	theme: string,
-	cookieOptions: ThemeProviderProps["cookieOptions"],
-	onStorageError?: (error: unknown) => void,
-): void {
-	try {
-		if (storage === "none") return;
-		if (storage === "cookie") {
-			writeCookie(storageKey, theme, cookieOptions);
-			return;
-		}
-		if (storage === "hybrid") {
-			writeCookie(storageKey, theme, cookieOptions);
-			localStorage.setItem(storageKey, theme);
-			return;
-		}
-		if (storage === "localStorage") {
-			localStorage.setItem(storageKey, theme);
-			return;
-		}
-		sessionStorage.setItem(storageKey, theme);
-	} catch (error) {
-		reportStorageError(onStorageError, error);
-	}
 }
 
 export function applyThemeToDom({

--- a/packages/themes/src/core/config-equal.ts
+++ b/packages/themes/src/core/config-equal.ts
@@ -1,0 +1,36 @@
+export function sameStringList(left: readonly string[], right: readonly string[]): boolean {
+	if (left === right) return true;
+	if (left.length !== right.length) return false;
+	for (let index = 0; index < left.length; index += 1) {
+		if (left[index] !== right[index]) return false;
+	}
+	return true;
+}
+
+export function sameStringRecord(
+	left: Partial<Record<string, string>> | undefined,
+	right: Partial<Record<string, string>> | undefined,
+): boolean {
+	if (left === right) return true;
+	if (!left || !right) return false;
+	const leftKeys = Object.keys(left);
+	const rightKeys = Object.keys(right);
+	if (leftKeys.length !== rightKeys.length) return false;
+	for (const key of leftKeys) {
+		if (left[key] !== right[key]) return false;
+	}
+	return true;
+}
+
+export function sameThemeColor(
+	left: string | Partial<Record<string, string>> | undefined,
+	right: string | Partial<Record<string, string>> | undefined,
+): boolean {
+	if (left === right) return true;
+	if (typeof left === "string" || typeof right === "string") return false;
+	return sameStringRecord(left, right);
+}
+
+export function holdIfEqual<T>(previous: T, next: T, equal: (left: T, right: T) => boolean): T {
+	return equal(previous, next) ? previous : next;
+}

--- a/packages/themes/src/core/extended-client-dom.ts
+++ b/packages/themes/src/core/extended-client-dom.ts
@@ -1,6 +1,6 @@
-import { writeCookie } from "./cookie.js";
-import type { ExtendedThemeProviderProps } from "./extended-types.js";
 import type { Attribute, ThemeColor } from "./types.js";
+
+export { getDomWindow, readStoredTheme, writeStoredTheme } from "./theme-storage.js";
 
 type ApplyExtendedThemeOptions = {
 	resolved: string;
@@ -76,76 +76,6 @@ function getTargetElement(target: string, themeRoot?: Element | ShadowRoot): Ele
 	if (target === "html") return document.documentElement;
 	if (target === "body") return document.body;
 	return document.querySelector(target);
-}
-
-function reportStorageError(
-	onStorageError: ((error: unknown) => void) | undefined,
-	error: unknown,
-): void {
-	try {
-		onStorageError?.(error);
-	} catch {}
-}
-
-function readCookieValue(key: string): string | null {
-	const parts = `; ${document.cookie}`.split(`; ${key}=`);
-	const encoded = parts.length > 1 ? parts.pop()?.split(";")[0] : null;
-	try {
-		return encoded ? decodeURIComponent(encoded) || null : null;
-	} catch {
-		return null;
-	}
-}
-
-export function getDomWindow(): (Window & typeof globalThis) | null {
-	if (typeof document === "undefined") return null;
-	return document.defaultView;
-}
-
-export function readStoredTheme(
-	storage: ExtendedThemeProviderProps["storage"],
-	storageKey: string,
-	onStorageError?: (error: unknown) => void,
-): string | null {
-	try {
-		if (storage === "none") return null;
-		if (storage === "cookie") return readCookieValue(storageKey);
-		if (storage === "hybrid")
-			return readCookieValue(storageKey) ?? localStorage.getItem(storageKey);
-		if (storage === "localStorage") return localStorage.getItem(storageKey);
-		return sessionStorage.getItem(storageKey);
-	} catch (error) {
-		reportStorageError(onStorageError, error);
-		return null;
-	}
-}
-
-export function writeStoredTheme(
-	storage: ExtendedThemeProviderProps["storage"],
-	storageKey: string,
-	theme: string,
-	cookieOptions: ExtendedThemeProviderProps["cookieOptions"],
-	onStorageError?: (error: unknown) => void,
-): void {
-	try {
-		if (storage === "none") return;
-		if (storage === "cookie") {
-			writeCookie(storageKey, theme, cookieOptions);
-			return;
-		}
-		if (storage === "hybrid") {
-			writeCookie(storageKey, theme, cookieOptions);
-			localStorage.setItem(storageKey, theme);
-			return;
-		}
-		if (storage === "localStorage") {
-			localStorage.setItem(storageKey, theme);
-			return;
-		}
-		sessionStorage.setItem(storageKey, theme);
-	} catch (error) {
-		reportStorageError(onStorageError, error);
-	}
 }
 
 export function applyExtendedThemeToDom({

--- a/packages/themes/src/core/theme-storage.ts
+++ b/packages/themes/src/core/theme-storage.ts
@@ -1,0 +1,72 @@
+import { writeCookie } from "./cookie.js";
+import type { CookieOptions, StorageType } from "./types.js";
+
+function reportStorageError(
+	onStorageError: ((error: unknown) => void) | undefined,
+	error: unknown,
+): void {
+	try {
+		onStorageError?.(error);
+	} catch {}
+}
+
+function readCookieValue(key: string): string | null {
+	const parts = `; ${document.cookie}`.split(`; ${key}=`);
+	const encoded = parts.length > 1 ? parts.pop()?.split(";")[0] : null;
+	try {
+		return encoded ? decodeURIComponent(encoded) || null : null;
+	} catch {
+		return null;
+	}
+}
+
+export function getDomWindow(): (Window & typeof globalThis) | null {
+	if (typeof document === "undefined") return null;
+	return document.defaultView;
+}
+
+export function readStoredTheme(
+	storage: StorageType | undefined,
+	storageKey: string,
+	onStorageError?: (error: unknown) => void,
+): string | null {
+	try {
+		if (storage === "none") return null;
+		if (storage === "cookie") return readCookieValue(storageKey);
+		if (storage === "hybrid")
+			return readCookieValue(storageKey) ?? localStorage.getItem(storageKey);
+		if (storage === "localStorage") return localStorage.getItem(storageKey);
+		return sessionStorage.getItem(storageKey);
+	} catch (error) {
+		reportStorageError(onStorageError, error);
+		return null;
+	}
+}
+
+export function writeStoredTheme(
+	storage: StorageType | undefined,
+	storageKey: string,
+	theme: string,
+	cookieOptions: CookieOptions | undefined,
+	onStorageError?: (error: unknown) => void,
+): void {
+	try {
+		if (storage === "none") return;
+		if (storage === "cookie") {
+			writeCookie(storageKey, theme, cookieOptions);
+			return;
+		}
+		if (storage === "hybrid") {
+			writeCookie(storageKey, theme, cookieOptions);
+			localStorage.setItem(storageKey, theme);
+			return;
+		}
+		if (storage === "localStorage") {
+			localStorage.setItem(storageKey, theme);
+			return;
+		}
+		sessionStorage.setItem(storageKey, theme);
+	} catch (error) {
+		reportStorageError(onStorageError, error);
+	}
+}

--- a/packages/themes/src/providers/client-provider.tsx
+++ b/packages/themes/src/providers/client-provider.tsx
@@ -1,29 +1,9 @@
 "use client";
 
-import {
-	type ReactElement,
-	useCallback,
-	useEffect,
-	useMemo,
-	useRef,
-	useSyncExternalStore,
-} from "react";
-import {
-	applyThemeToDom,
-	getDomWindow,
-	readStoredTheme,
-	writeStoredTheme,
-} from "../core/client-dom.js";
-import {
-	holdIfEqual,
-	sameStringList,
-	sameStringRecord,
-	sameThemeColor,
-} from "../core/config-equal.js";
+import { type ReactElement, useMemo } from "react";
+import { applyThemeToDom } from "../core/client-dom.js";
 import { ThemeContext, type ThemeContextInstance } from "../core/context.js";
-import { subscribeHistoryReapply } from "../core/history-reapply.js";
-import { createThemeStore } from "../core/store.js";
-import { isThemeSelection, resolveDefaultTheme } from "../core/theme-validation.js";
+import { isThemeSelection } from "../core/theme-validation.js";
 import type {
 	Attribute,
 	DefaultTheme,
@@ -31,9 +11,7 @@ import type {
 	ThemeContextValue,
 	ThemeProviderProps,
 } from "../core/types.js";
-import { useEffectEvent } from "../core/use-effect-event.js";
-
-const DEFAULT_THEMES: string[] = ["light", "dark"];
+import { type ClientThemeStableConfig, useClientThemeRuntime } from "./client-theme-runtime.js";
 
 type LastAppliedTheme = {
 	resolved: string;
@@ -53,7 +31,7 @@ export type ClientThemeProviderProps<Themes extends string = DefaultTheme> =
 
 export function ClientThemeProvider<Themes extends string = DefaultTheme>({
 	children,
-	themes = DEFAULT_THEMES as Themes[],
+	themes,
 	forcedTheme,
 	enableSystem = true,
 	defaultTheme,
@@ -61,256 +39,69 @@ export function ClientThemeProvider<Themes extends string = DefaultTheme>({
 	value: valueMap,
 	target = "html",
 	disableTransitionOnChange = false,
-	storage = "localStorage",
-	storageKey = "theme",
+	storage,
+	storageKey,
 	enableColorScheme = true,
 	themeColor,
-	followSystem = false,
+	followSystem,
 	onThemeChange,
 	initialTheme,
 	cookieOptions,
 	onStorageError,
 	themeContext = ThemeContext as ThemeContextInstance<Themes>,
 }: ClientThemeProviderProps<Themes>): ReactElement {
-	const resolvedDefault = resolveDefaultTheme(themes, enableSystem, defaultTheme);
-
-	const storeRef = useRef<ReturnType<typeof createThemeStore> | null>(null);
-	if (storeRef.current === null) {
-		storeRef.current = createThemeStore();
-	}
-	const store = storeRef.current;
-	const {
-		getSnapshot,
-		setState: setStoreState,
-		setTheme: setStoreTheme,
-		setSystemTheme: setStoreSystemTheme,
-	} = store;
-
-	const { theme, systemTheme } = useSyncExternalStore(
-		store.subscribe,
-		store.getSnapshot,
-		store.getServerSnapshot,
-	);
-	const lastAppliedRef = useRef<LastAppliedTheme | null>(null);
-	const themesRef = useRef(themes);
-	themesRef.current = holdIfEqual(themesRef.current, themes, sameStringList);
-	const stableThemes = themesRef.current;
-	const valueMapRef = useRef(valueMap);
-	valueMapRef.current = holdIfEqual(valueMapRef.current, valueMap, sameStringRecord);
-	const stableValueMap = valueMapRef.current;
-	const themeColorRef = useRef(themeColor);
-	themeColorRef.current = holdIfEqual(themeColorRef.current, themeColor, sameThemeColor);
-	const stableThemeColor = themeColorRef.current;
-
-	const validForcedTheme =
-		forcedTheme && stableThemes.includes(forcedTheme) ? forcedTheme : undefined;
-	const selectedTheme = validForcedTheme ?? theme;
-	const resolvedTheme: ResolvedTheme<Themes> | undefined =
-		selectedTheme === "system" || selectedTheme === undefined
-			? (systemTheme as ResolvedTheme<Themes> | undefined)
-			: (selectedTheme as ResolvedTheme<Themes>);
-
-	const onThemeChangeEvent = useEffectEvent((next: Themes) => {
-		onThemeChange?.(next);
-	});
-
-	const applyToDomEvent = useEffectEvent((resolved: string) => {
-		const last: LastAppliedTheme = {
-			resolved,
-			attribute,
-			themes: stableThemes,
-			valueMap: stableValueMap,
-			target,
-			disableTransitionOnChange,
-			enableColorScheme,
-			themeColor: stableThemeColor,
-		};
-		applyThemeToDom(last);
-		lastAppliedRef.current = last;
-	});
-	const initializeEvent = useEffectEvent(() => {
-		const domWindow = getDomWindow();
-		if (!domWindow) return;
-		const mq =
-			enableSystem && typeof domWindow.matchMedia === "function"
-				? domWindow.matchMedia("(prefers-color-scheme: dark)")
-				: null;
-		const system = mq ? (mq.matches ? "dark" : "light") : undefined;
-		let initial: Themes | "system";
-
-		// Forced theme short-circuits init and must not persist to storage.
-		if (validForcedTheme) {
-			initial = validForcedTheme;
-		} else if (initialTheme && isThemeSelection(initialTheme, themes, enableSystem)) {
-			initial = initialTheme;
-			writeStoredTheme(
-				storage,
-				storageKey,
-				String(initialTheme),
-				cookieOptions,
-				onStorageError,
-			);
-		} else {
-			const stored = readStoredTheme(storage, storageKey, onStorageError);
-			initial =
-				!followSystem && stored && isThemeSelection(stored, themes, enableSystem)
-					? (stored as Themes | "system")
-					: resolvedDefault;
-		}
-
-		setStoreState({ theme: initial, systemTheme: system });
-	});
-	const handleSystemChangeEvent = useEffectEvent((next: "light" | "dark") => {
-		setStoreSystemTheme(next);
-		const current = getSnapshot().theme;
-		if (current === "system" || current === undefined || followSystem) {
-			if (followSystem) {
-				setStoreTheme("system");
-			}
-			applyToDomEvent(next);
-			onThemeChangeEvent(next as Themes);
-		}
-	});
-	// Public API: must be a regular callback (not an Effect Event) so consumers can
-	// call it from event handlers and receive it via context under oxlint rules.
-	// oxlint-disable-next-line react-hooks/exhaustive-deps -- applyToDomEvent is an effect event.
-	const setTheme = useCallback(
-		(
-			next:
-				| Themes
-				| "system"
-				| ((current: Themes | "system" | undefined) => Themes | "system"),
-		) => {
-			if (validForcedTheme) return;
-
-			const current = getSnapshot().theme as Themes | "system" | undefined;
-			const newTheme = typeof next === "function" ? next(current) : next;
-			if (!isThemeSelection(newTheme, stableThemes, enableSystem)) return;
-			const resolved =
-				newTheme === "system" ? (getSnapshot().systemTheme ?? "light") : newTheme;
-
-			setStoreTheme(newTheme);
-			// oxlint-disable-next-line react-hooks/rules-of-hooks -- shared apply path; setTheme stays a public callback.
-			applyToDomEvent(resolved);
-			onThemeChange?.(newTheme as Themes);
-
-			writeStoredTheme(storage, storageKey, newTheme, cookieOptions, onStorageError);
-		},
-		[
-			validForcedTheme,
-			stableThemes,
+	const { theme, systemTheme, resolvedTheme, validForcedTheme, stableThemes, setTheme } =
+		useClientThemeRuntime<Themes, LastAppliedTheme>({
+			themes,
+			forcedTheme,
 			enableSystem,
+			defaultTheme,
+			value: valueMap,
 			storage,
 			storageKey,
+			followSystem,
+			onThemeChange,
+			initialTheme,
 			cookieOptions,
 			onStorageError,
-			getSnapshot,
-			setStoreTheme,
-			onThemeChange,
-		],
-	);
-
-	// oxlint-disable-next-line react-hooks/exhaustive-deps -- effect events are intentionally non-reactive.
-	useEffect(() => {
-		initializeEvent();
-		const domWindow = getDomWindow();
-		if (!domWindow) return;
-		return subscribeHistoryReapply(domWindow, () => {
-			const last = lastAppliedRef.current;
-			if (last) applyThemeToDom(last);
+			themeColor,
+			resolveTheme: (selection, systemThemeValue) =>
+				selection === "system" ? systemThemeValue : selection,
+			createLast: (resolved, config: ClientThemeStableConfig) => ({
+				resolved,
+				attribute,
+				themes: config.themes,
+				valueMap: config.valueMap,
+				target,
+				disableTransitionOnChange,
+				enableColorScheme,
+				themeColor: config.themeColor,
+			}),
+			sameLast: (last, resolved, config) =>
+				last.resolved === resolved &&
+				last.attribute === attribute &&
+				last.themes === config.themes &&
+				last.valueMap === config.valueMap &&
+				last.target === target &&
+				last.disableTransitionOnChange === disableTransitionOnChange &&
+				last.enableColorScheme === enableColorScheme &&
+				last.themeColor === config.themeColor,
+			applyLast: (last) => {
+				applyThemeToDom(last);
+			},
 		});
-	}, []);
-
-	// setTheme / system / storage already write the DOM. Re-apply only when
-	// resolvedTheme or DOM config changed from outside those paths.
-	// oxlint-disable-next-line react-hooks/exhaustive-deps -- effect events are intentionally non-reactive.
-	useEffect(() => {
-		if (!resolvedTheme) return;
-		const last = lastAppliedRef.current;
-		if (
-			last &&
-			last.resolved === resolvedTheme &&
-			last.attribute === attribute &&
-			last.themes === stableThemes &&
-			last.valueMap === stableValueMap &&
-			last.target === target &&
-			last.disableTransitionOnChange === disableTransitionOnChange &&
-			last.enableColorScheme === enableColorScheme &&
-			last.themeColor === stableThemeColor
-		) {
-			return;
-		}
-		applyToDomEvent(resolvedTheme);
-	}, [
-		resolvedTheme,
-		attribute,
-		stableThemes,
-		stableValueMap,
-		target,
-		disableTransitionOnChange,
-		enableColorScheme,
-		stableThemeColor,
-	]);
-
-	// oxlint-disable-next-line react-hooks/exhaustive-deps -- effect events are intentionally non-reactive.
-	useEffect(() => {
-		const domWindow = getDomWindow();
-		if (!enableSystem || !domWindow || typeof domWindow.matchMedia !== "function") return;
-		const mq = domWindow.matchMedia("(prefers-color-scheme: dark)");
-		setStoreSystemTheme(mq.matches ? "dark" : "light");
-		const handler = (event: MediaQueryListEvent) => {
-			handleSystemChangeEvent(event.matches ? "dark" : "light");
-		};
-		mq.addEventListener?.("change", handler);
-		return () => mq.removeEventListener?.("change", handler);
-	}, [enableSystem, setStoreSystemTheme]);
-
-	// oxlint-disable-next-line react-hooks/exhaustive-deps -- effect events are intentionally non-reactive.
-	useEffect(() => {
-		const domWindow = getDomWindow();
-		if (!domWindow) return;
-		if (
-			followSystem ||
-			storage === "none" ||
-			storage === "sessionStorage" ||
-			storage === "cookie"
-		)
-			return;
-
-		const handler = (e: StorageEvent) => {
-			if (e.storageArea !== localStorage || e.key !== storageKey) return;
-			const newTheme = e.newValue ?? resolvedDefault;
-			if (!isThemeSelection(newTheme, themes, enableSystem)) return;
-			const resolved =
-				newTheme === "system" ? (getSnapshot().systemTheme ?? "light") : newTheme;
-			setStoreTheme(newTheme);
-			if (!validForcedTheme) applyToDomEvent(resolved);
-		};
-		domWindow.addEventListener("storage", handler);
-		return () => domWindow.removeEventListener("storage", handler);
-	}, [
-		followSystem,
-		storage,
-		storageKey,
-		resolvedDefault,
-		themes,
-		enableSystem,
-		validForcedTheme,
-		getSnapshot,
-		setStoreTheme,
-	]);
 
 	const contextTheme =
-		theme !== undefined && isThemeSelection(theme, themes, enableSystem)
+		theme !== undefined && isThemeSelection(theme, stableThemes, enableSystem)
 			? (theme as Themes | "system")
 			: undefined;
 	const contextValue = useMemo(
 		(): ThemeContextValue<Themes> => ({
 			theme: validForcedTheme ?? contextTheme,
-			resolvedTheme,
+			resolvedTheme: resolvedTheme as ResolvedTheme<Themes> | undefined,
 			systemTheme,
 			forcedTheme: validForcedTheme,
-			themes: stableThemes,
+			themes: stableThemes as readonly Themes[],
 			setTheme,
 		}),
 		[validForcedTheme, contextTheme, resolvedTheme, systemTheme, stableThemes, setTheme],

--- a/packages/themes/src/providers/client-provider.tsx
+++ b/packages/themes/src/providers/client-provider.tsx
@@ -14,6 +14,12 @@ import {
 	readStoredTheme,
 	writeStoredTheme,
 } from "../core/client-dom.js";
+import {
+	holdIfEqual,
+	sameStringList,
+	sameStringRecord,
+	sameThemeColor,
+} from "../core/config-equal.js";
 import { ThemeContext, type ThemeContextInstance } from "../core/context.js";
 import { subscribeHistoryReapply } from "../core/history-reapply.js";
 import { createThemeStore } from "../core/store.js";
@@ -86,8 +92,18 @@ export function ClientThemeProvider<Themes extends string = DefaultTheme>({
 		store.getServerSnapshot,
 	);
 	const lastAppliedRef = useRef<LastAppliedTheme | null>(null);
+	const themesRef = useRef(themes);
+	themesRef.current = holdIfEqual(themesRef.current, themes, sameStringList);
+	const stableThemes = themesRef.current;
+	const valueMapRef = useRef(valueMap);
+	valueMapRef.current = holdIfEqual(valueMapRef.current, valueMap, sameStringRecord);
+	const stableValueMap = valueMapRef.current;
+	const themeColorRef = useRef(themeColor);
+	themeColorRef.current = holdIfEqual(themeColorRef.current, themeColor, sameThemeColor);
+	const stableThemeColor = themeColorRef.current;
 
-	const validForcedTheme = forcedTheme && themes.includes(forcedTheme) ? forcedTheme : undefined;
+	const validForcedTheme =
+		forcedTheme && stableThemes.includes(forcedTheme) ? forcedTheme : undefined;
 	const selectedTheme = validForcedTheme ?? theme;
 	const resolvedTheme: ResolvedTheme<Themes> | undefined =
 		selectedTheme === "system" || selectedTheme === undefined
@@ -102,12 +118,12 @@ export function ClientThemeProvider<Themes extends string = DefaultTheme>({
 		const last: LastAppliedTheme = {
 			resolved,
 			attribute,
-			themes,
-			valueMap,
+			themes: stableThemes,
+			valueMap: stableValueMap,
 			target,
 			disableTransitionOnChange,
 			enableColorScheme,
-			themeColor,
+			themeColor: stableThemeColor,
 		};
 		applyThemeToDom(last);
 		lastAppliedRef.current = last;
@@ -169,7 +185,7 @@ export function ClientThemeProvider<Themes extends string = DefaultTheme>({
 
 			const current = getSnapshot().theme as Themes | "system" | undefined;
 			const newTheme = typeof next === "function" ? next(current) : next;
-			if (!isThemeSelection(newTheme, themes, enableSystem)) return;
+			if (!isThemeSelection(newTheme, stableThemes, enableSystem)) return;
 			const resolved =
 				newTheme === "system" ? (getSnapshot().systemTheme ?? "light") : newTheme;
 
@@ -182,7 +198,7 @@ export function ClientThemeProvider<Themes extends string = DefaultTheme>({
 		},
 		[
 			validForcedTheme,
-			themes,
+			stableThemes,
 			enableSystem,
 			storage,
 			storageKey,
@@ -215,12 +231,12 @@ export function ClientThemeProvider<Themes extends string = DefaultTheme>({
 			last &&
 			last.resolved === resolvedTheme &&
 			last.attribute === attribute &&
-			last.themes === themes &&
-			last.valueMap === valueMap &&
+			last.themes === stableThemes &&
+			last.valueMap === stableValueMap &&
 			last.target === target &&
 			last.disableTransitionOnChange === disableTransitionOnChange &&
 			last.enableColorScheme === enableColorScheme &&
-			last.themeColor === themeColor
+			last.themeColor === stableThemeColor
 		) {
 			return;
 		}
@@ -228,12 +244,12 @@ export function ClientThemeProvider<Themes extends string = DefaultTheme>({
 	}, [
 		resolvedTheme,
 		attribute,
-		themes,
-		valueMap,
+		stableThemes,
+		stableValueMap,
 		target,
 		disableTransitionOnChange,
 		enableColorScheme,
-		themeColor,
+		stableThemeColor,
 	]);
 
 	// oxlint-disable-next-line react-hooks/exhaustive-deps -- effect events are intentionally non-reactive.
@@ -294,10 +310,10 @@ export function ClientThemeProvider<Themes extends string = DefaultTheme>({
 			resolvedTheme,
 			systemTheme,
 			forcedTheme: validForcedTheme,
-			themes,
+			themes: stableThemes,
 			setTheme,
 		}),
-		[validForcedTheme, contextTheme, resolvedTheme, systemTheme, themes, setTheme],
+		[validForcedTheme, contextTheme, resolvedTheme, systemTheme, stableThemes, setTheme],
 	);
 	const ContextProvider = themeContext.Provider;
 

--- a/packages/themes/src/providers/client-theme-runtime.ts
+++ b/packages/themes/src/providers/client-theme-runtime.ts
@@ -1,0 +1,333 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useSyncExternalStore } from "react";
+import {
+	holdIfEqual,
+	sameStringList,
+	sameStringRecord,
+	sameThemeColor,
+} from "../core/config-equal.js";
+import { subscribeHistoryReapply } from "../core/history-reapply.js";
+import { createThemeStore, type ThemeStore } from "../core/store.js";
+import { getDomWindow, readStoredTheme, writeStoredTheme } from "../core/theme-storage.js";
+import { isThemeSelection, resolveDefaultTheme } from "../core/theme-validation.js";
+import type {
+	CookieOptions,
+	DefaultTheme,
+	StorageType,
+	ThemeColor,
+	ThemeSelection,
+	ThemeValueObject,
+} from "../core/types.js";
+import { useEffectEvent } from "../core/use-effect-event.js";
+
+const DEFAULT_THEMES: string[] = ["light", "dark"];
+const NOOP = () => {};
+
+export type ClientThemeStableConfig = {
+	themes: readonly string[];
+	valueMap: ThemeValueObject | undefined;
+	themeColor: ThemeColor | undefined;
+};
+
+export type ClientThemeRuntimeConfig<Themes extends string = DefaultTheme, Last = unknown> = {
+	themes?: readonly Themes[] | undefined;
+	forcedTheme?: Themes | undefined;
+	enableSystem?: boolean | undefined;
+	defaultTheme?: Themes | "system" | undefined;
+	value?: ThemeValueObject<Themes> | undefined;
+	storage?: StorageType | undefined;
+	storageKey?: string | undefined;
+	followSystem?: boolean | undefined;
+	onThemeChange?: ((theme: ThemeSelection<Themes>) => void) | undefined;
+	initialTheme?: ThemeSelection<Themes> | undefined;
+	cookieOptions?: CookieOptions | undefined;
+	onStorageError?: ((error: unknown) => void) | undefined;
+	themeColor?: ThemeColor<Themes> | undefined;
+	keepSystemSelection?: boolean | undefined;
+	resolveTheme: (
+		selection: string,
+		systemTheme: "light" | "dark" | undefined,
+	) => string | undefined;
+	createLast: (resolved: string, config: ClientThemeStableConfig) => Last;
+	sameLast: (last: Last, resolved: string, config: ClientThemeStableConfig) => boolean;
+	applyLast: (last: Last) => void;
+	afterSetTheme?: ((newTheme: string) => void) | undefined;
+};
+
+export type ClientThemeRuntime<Themes extends string> = {
+	theme: string | undefined;
+	systemTheme: "light" | "dark" | undefined;
+	resolvedTheme: string | undefined;
+	validForcedTheme: Themes | undefined;
+	stableThemes: readonly string[];
+	stableValueMap: ThemeValueObject | undefined;
+	stableThemeColor: ThemeColor | undefined;
+	setTheme: (
+		next: Themes | "system" | ((current: Themes | "system" | undefined) => Themes | "system"),
+	) => void;
+	getSnapshot: ThemeStore["getSnapshot"];
+	setStoreTheme: ThemeStore["setTheme"];
+	applyResolved: (resolved: string) => void;
+};
+
+export function useClientThemeRuntime<Themes extends string, Last>(
+	config: ClientThemeRuntimeConfig<Themes, Last>,
+): ClientThemeRuntime<Themes> {
+	const {
+		themes = DEFAULT_THEMES as Themes[],
+		forcedTheme,
+		enableSystem = true,
+		defaultTheme,
+		value: valueMap,
+		storage = "localStorage",
+		storageKey = "theme",
+		followSystem = false,
+		onThemeChange,
+		initialTheme,
+		cookieOptions,
+		onStorageError,
+		themeColor,
+		keepSystemSelection = false,
+		resolveTheme,
+		createLast,
+		sameLast,
+		applyLast,
+		afterSetTheme = NOOP,
+	} = config;
+
+	const resolvedDefault = resolveDefaultTheme(themes, enableSystem, defaultTheme);
+
+	const storeRef = useRef<ReturnType<typeof createThemeStore> | null>(null);
+	if (storeRef.current === null) {
+		storeRef.current = createThemeStore();
+	}
+	const store = storeRef.current;
+	const {
+		getSnapshot,
+		setState: setStoreState,
+		setTheme: setStoreTheme,
+		setSystemTheme: setStoreSystemTheme,
+	} = store;
+
+	const { theme, systemTheme } = useSyncExternalStore(
+		store.subscribe,
+		store.getSnapshot,
+		store.getServerSnapshot,
+	);
+	const lastAppliedRef = useRef<Last | null>(null);
+	const themesRef = useRef(themes);
+	themesRef.current = holdIfEqual(themesRef.current, themes, sameStringList);
+	const stableThemes = themesRef.current;
+	const valueMapRef = useRef(valueMap);
+	valueMapRef.current = holdIfEqual(valueMapRef.current, valueMap, sameStringRecord);
+	const stableValueMap = valueMapRef.current;
+	const themeColorRef = useRef(themeColor);
+	themeColorRef.current = holdIfEqual(themeColorRef.current, themeColor, sameThemeColor);
+	const stableThemeColor = themeColorRef.current;
+	const stableConfig: ClientThemeStableConfig = {
+		themes: stableThemes,
+		valueMap: stableValueMap,
+		themeColor: stableThemeColor,
+	};
+
+	const validForcedTheme =
+		forcedTheme && stableThemes.includes(forcedTheme) ? forcedTheme : undefined;
+	const selectedTheme = validForcedTheme ?? theme;
+	const resolvedTheme = selectedTheme ? resolveTheme(selectedTheme, systemTheme) : undefined;
+
+	const onThemeChangeEvent = useEffectEvent((next: Themes) => {
+		onThemeChange?.(next);
+	});
+	const resolveThemeEvent = useEffectEvent(resolveTheme);
+	const createLastEvent = useEffectEvent(createLast);
+	const sameLastEvent = useEffectEvent(sameLast);
+	const applyLastEvent = useEffectEvent(applyLast);
+	const afterSetThemeEvent = useEffectEvent(afterSetTheme);
+
+	const applyResolvedEvent = useEffectEvent((resolved: string) => {
+		const last = createLastEvent(resolved, stableConfig);
+		applyLastEvent(last);
+		lastAppliedRef.current = last;
+	});
+
+	const initializeEvent = useEffectEvent(() => {
+		const domWindow = getDomWindow();
+		if (!domWindow) return;
+		const mq =
+			enableSystem && typeof domWindow.matchMedia === "function"
+				? domWindow.matchMedia("(prefers-color-scheme: dark)")
+				: null;
+		const system = mq ? (mq.matches ? "dark" : "light") : undefined;
+		let initial: Themes | "system";
+
+		// Forced theme short-circuits init and must not persist to storage.
+		if (validForcedTheme) {
+			initial = validForcedTheme;
+		} else if (initialTheme && isThemeSelection(initialTheme, themes, enableSystem)) {
+			initial = initialTheme;
+			writeStoredTheme(
+				storage,
+				storageKey,
+				String(initialTheme),
+				cookieOptions,
+				onStorageError,
+			);
+		} else {
+			const stored = readStoredTheme(storage, storageKey, onStorageError);
+			initial =
+				!followSystem && stored && isThemeSelection(stored, themes, enableSystem)
+					? (stored as Themes | "system")
+					: resolvedDefault;
+		}
+
+		setStoreState({ theme: initial, systemTheme: system });
+	});
+
+	const handleSystemChangeEvent = useEffectEvent((next: "light" | "dark") => {
+		setStoreSystemTheme(next);
+		const current = getSnapshot().theme;
+		if (current === "system" || current === undefined || followSystem) {
+			const keepSelection = followSystem && keepSystemSelection;
+			if (followSystem && !keepSelection) {
+				setStoreTheme("system");
+			}
+			const selection = keepSelection
+				? (current ?? resolvedDefault)
+				: followSystem
+					? "system"
+					: (current ?? "system");
+			const resolved = resolveThemeEvent(selection, next) ?? next;
+			applyResolvedEvent(resolved);
+			onThemeChangeEvent(next as Themes);
+		}
+	});
+
+	// Public API: must be a regular callback (not an Effect Event) so consumers can
+	// call it from event handlers and receive it via context under oxlint rules.
+	// oxlint-disable-next-line react-hooks/exhaustive-deps -- applyResolvedEvent is an effect event.
+	const setTheme = useCallback(
+		(
+			next:
+				| Themes
+				| "system"
+				| ((current: Themes | "system" | undefined) => Themes | "system"),
+		): void => {
+			if (validForcedTheme) return;
+
+			const current = getSnapshot().theme as Themes | "system" | undefined;
+			const newTheme = typeof next === "function" ? next(current) : next;
+			if (!isThemeSelection(newTheme, stableThemes, enableSystem)) return;
+			const resolved =
+				// oxlint-disable-next-line react-hooks/rules-of-hooks -- shared apply path; setTheme stays a public callback.
+				resolveThemeEvent(newTheme, getSnapshot().systemTheme) ??
+				(newTheme === "system" ? "light" : newTheme);
+
+			setStoreTheme(newTheme);
+			// oxlint-disable-next-line react-hooks/rules-of-hooks -- shared apply path; setTheme stays a public callback.
+			applyResolvedEvent(resolved);
+			onThemeChange?.(newTheme as Themes);
+
+			writeStoredTheme(storage, storageKey, newTheme, cookieOptions, onStorageError);
+			// oxlint-disable-next-line react-hooks/rules-of-hooks -- shared apply path; setTheme stays a public callback.
+			afterSetThemeEvent(newTheme);
+		},
+		[
+			validForcedTheme,
+			stableThemes,
+			enableSystem,
+			storage,
+			storageKey,
+			cookieOptions,
+			onStorageError,
+			getSnapshot,
+			setStoreTheme,
+			onThemeChange,
+		],
+	);
+
+	// oxlint-disable-next-line react-hooks/exhaustive-deps -- effect events are intentionally non-reactive.
+	useEffect(() => {
+		initializeEvent();
+		const domWindow = getDomWindow();
+		if (!domWindow) return;
+		return subscribeHistoryReapply(domWindow, () => {
+			const last = lastAppliedRef.current;
+			if (last) applyLastEvent(last);
+		});
+	}, []);
+
+	// setTheme / system / storage already write the DOM. Re-apply only when
+	// resolvedTheme or DOM config changed from outside those paths.
+	// oxlint-disable-next-line react-hooks/exhaustive-deps -- effect events are intentionally non-reactive.
+	useEffect(() => {
+		if (!resolvedTheme) return;
+		const last = lastAppliedRef.current;
+		if (last && sameLastEvent(last, resolvedTheme, stableConfig)) return;
+		applyResolvedEvent(resolvedTheme);
+	});
+
+	// oxlint-disable-next-line react-hooks/exhaustive-deps -- effect events are intentionally non-reactive.
+	useEffect(() => {
+		const domWindow = getDomWindow();
+		if (!enableSystem || !domWindow || typeof domWindow.matchMedia !== "function") return;
+		const mq = domWindow.matchMedia("(prefers-color-scheme: dark)");
+		setStoreSystemTheme(mq.matches ? "dark" : "light");
+		const handler = (event: MediaQueryListEvent) => {
+			handleSystemChangeEvent(event.matches ? "dark" : "light");
+		};
+		mq.addEventListener?.("change", handler);
+		return () => mq.removeEventListener?.("change", handler);
+	}, [enableSystem, setStoreSystemTheme]);
+
+	// oxlint-disable-next-line react-hooks/exhaustive-deps -- effect events are intentionally non-reactive.
+	useEffect(() => {
+		const domWindow = getDomWindow();
+		if (!domWindow) return;
+		if (
+			followSystem ||
+			storage === "none" ||
+			storage === "sessionStorage" ||
+			storage === "cookie"
+		)
+			return;
+
+		const handler = (event: StorageEvent) => {
+			if (event.storageArea !== localStorage || event.key !== storageKey) return;
+			const newTheme = event.newValue ?? resolvedDefault;
+			if (!isThemeSelection(newTheme, themes, enableSystem)) return;
+			const resolved = resolveThemeEvent(newTheme, getSnapshot().systemTheme);
+			setStoreTheme(newTheme);
+			if (!validForcedTheme && resolved) applyResolvedEvent(resolved);
+		};
+		domWindow.addEventListener("storage", handler);
+		return () => domWindow.removeEventListener("storage", handler);
+	}, [
+		followSystem,
+		storage,
+		storageKey,
+		resolvedDefault,
+		themes,
+		enableSystem,
+		validForcedTheme,
+		getSnapshot,
+		setStoreTheme,
+	]);
+
+	// oxlint-disable-next-line react-hooks/rules-of-hooks -- callers outside effects still need the latest apply.
+	const applyResolved = applyResolvedEvent;
+
+	return {
+		theme,
+		systemTheme,
+		resolvedTheme,
+		validForcedTheme,
+		stableThemes,
+		stableValueMap,
+		stableThemeColor,
+		setTheme,
+		getSnapshot,
+		setStoreTheme,
+		applyResolved,
+	};
+}

--- a/packages/themes/src/providers/extended-client-provider.tsx
+++ b/packages/themes/src/providers/extended-client-provider.tsx
@@ -1,36 +1,14 @@
 "use client";
 
-import {
-	type ReactElement,
-	useCallback,
-	useEffect,
-	useMemo,
-	useRef,
-	useSyncExternalStore,
-} from "react";
-import {
-	holdIfEqual,
-	sameStringList,
-	sameStringRecord,
-	sameThemeColor,
-} from "../core/config-equal.js";
+import { type ReactElement, useEffect, useMemo, useRef } from "react";
 import { ThemeContext } from "../core/context.js";
-import {
-	type AppliedThemeState,
-	applyExtendedThemeToDom,
-	getDomWindow,
-	readStoredTheme,
-	writeStoredTheme,
-} from "../core/extended-client-dom.js";
-import { subscribeHistoryReapply } from "../core/history-reapply.js";
+import { type AppliedThemeState, applyExtendedThemeToDom } from "../core/extended-client-dom.js";
 import type { ExtendedThemeProviderProps, SystemThemeMap } from "../core/extended-types.js";
-import { createThemeStore } from "../core/store.js";
 import { publishThemeChannel, subscribeThemeChannel } from "../core/sync.js";
-import { isThemeSelection, resolveDefaultTheme } from "../core/theme-validation.js";
+import { isThemeSelection } from "../core/theme-validation.js";
 import type { Attribute, DefaultTheme, ThemeContextValue } from "../core/types.js";
 import { useEffectEvent } from "../core/use-effect-event.js";
-
-const DEFAULT_THEMES: string[] = ["light", "dark"];
+import { type ClientThemeStableConfig, useClientThemeRuntime } from "./client-theme-runtime.js";
 
 type LastAppliedTheme = {
 	resolved: string;
@@ -71,7 +49,7 @@ function resolveSelection(
 
 export function ExtendedClientThemeProvider<Themes extends string = DefaultTheme>({
 	children,
-	themes = DEFAULT_THEMES as Themes[],
+	themes,
 	forcedTheme,
 	enableSystem = true,
 	defaultTheme,
@@ -79,11 +57,11 @@ export function ExtendedClientThemeProvider<Themes extends string = DefaultTheme
 	value: valueMap,
 	target = "html",
 	disableTransitionOnChange = false,
-	storage = "localStorage",
+	storage,
 	storageKey = "theme",
 	enableColorScheme = true,
 	themeColor,
-	followSystem = false,
+	followSystem,
 	onThemeChange,
 	initialTheme,
 	cookieOptions,
@@ -92,291 +70,90 @@ export function ExtendedClientThemeProvider<Themes extends string = DefaultTheme
 	systemThemeMap,
 	themeRoot,
 }: ExtendedThemeProviderProps<Themes>): ReactElement {
-	const resolvedDefault = resolveDefaultTheme(themes, enableSystem, defaultTheme);
-
-	const storeRef = useRef<ReturnType<typeof createThemeStore> | null>(null);
-	if (storeRef.current === null) {
-		storeRef.current = createThemeStore();
-	}
-	const store = storeRef.current;
 	const appliedThemeRef = useRef<AppliedThemeState | undefined>(undefined);
-	const lastAppliedRef = useRef<LastAppliedTheme | null>(null);
-	const themesRef = useRef(themes);
-	themesRef.current = holdIfEqual(themesRef.current, themes, sameStringList);
-	const stableThemes = themesRef.current;
-	const valueMapRef = useRef(valueMap);
-	valueMapRef.current = holdIfEqual(valueMapRef.current, valueMap, sameStringRecord);
-	const stableValueMap = valueMapRef.current;
-	const themeColorRef = useRef(themeColor);
-	themeColorRef.current = holdIfEqual(themeColorRef.current, themeColor, sameThemeColor);
-	const stableThemeColor = themeColorRef.current;
-	const {
-		getSnapshot,
-		setState: setStoreState,
-		setTheme: setStoreTheme,
-		setSystemTheme: setStoreSystemTheme,
-	} = store;
-
-	const { theme, systemTheme } = useSyncExternalStore(
-		store.subscribe,
-		store.getSnapshot,
-		store.getServerSnapshot,
-	);
-
-	const validForcedTheme =
-		forcedTheme && stableThemes.includes(forcedTheme) ? forcedTheme : undefined;
-	const selectedTheme = validForcedTheme ?? theme;
-	const resolvedTheme = selectedTheme
-		? (resolveSelection(
-				selectedTheme,
-				systemTheme,
-				systemThemeMap as SystemThemeMap<string> | undefined,
-			) as Themes | undefined)
-		: undefined;
 	const channel = `${storage ?? "localStorage"}:${storageKey}:${target}`;
 
-	const onThemeChangeEvent = useEffectEvent((next: Themes) => {
-		onThemeChange?.(next);
-	});
-
-	const applyToDomEvent = useEffectEvent((resolved: string) => {
-		const last: LastAppliedTheme = {
+	const {
+		theme,
+		systemTheme,
+		resolvedTheme,
+		validForcedTheme,
+		stableThemes,
+		setTheme,
+		getSnapshot,
+		setStoreTheme,
+		applyResolved,
+	} = useClientThemeRuntime<Themes, LastAppliedTheme>({
+		themes,
+		forcedTheme,
+		enableSystem,
+		defaultTheme,
+		value: valueMap,
+		storage,
+		storageKey,
+		followSystem,
+		onThemeChange,
+		initialTheme,
+		cookieOptions,
+		onStorageError,
+		themeColor,
+		keepSystemSelection: !!systemThemeMap && !isDirectSystemMap(systemThemeMap),
+		resolveTheme: (selection, systemThemeValue) =>
+			resolveSelection(
+				selection,
+				systemThemeValue,
+				systemThemeMap as SystemThemeMap<string> | undefined,
+			),
+		createLast: (resolved, config: ClientThemeStableConfig) => ({
 			resolved,
 			attribute,
-			themes: stableThemes,
-			valueMap: stableValueMap,
+			themes: config.themes,
+			valueMap: config.valueMap,
 			target,
 			disableTransitionOnChange,
 			enableColorScheme,
-			themeColor: stableThemeColor,
+			themeColor: config.themeColor,
 			themeRoot,
-		};
-		appliedThemeRef.current = applyExtendedThemeToDom({
-			...last,
-			previous: appliedThemeRef.current,
-		});
-		lastAppliedRef.current = last;
-	});
-
-	const initializeEvent = useEffectEvent(() => {
-		const domWindow = getDomWindow();
-		if (!domWindow) return;
-		const mq =
-			enableSystem && typeof domWindow.matchMedia === "function"
-				? domWindow.matchMedia("(prefers-color-scheme: dark)")
-				: null;
-		const system = mq ? (mq.matches ? "dark" : "light") : undefined;
-		let initial: Themes | "system";
-
-		// Forced theme short-circuits init and must not persist to storage.
-		if (validForcedTheme) {
-			initial = validForcedTheme;
-		} else if (initialTheme && isThemeSelection(initialTheme, themes, enableSystem)) {
-			initial = initialTheme;
-			writeStoredTheme(
-				storage,
-				storageKey,
-				String(initialTheme),
-				cookieOptions,
-				onStorageError,
-			);
-		} else {
-			const stored = readStoredTheme(storage, storageKey, onStorageError);
-			initial =
-				!followSystem && stored && isThemeSelection(stored, themes, enableSystem)
-					? (stored as Themes | "system")
-					: resolvedDefault;
-		}
-
-		setStoreState({ theme: initial, systemTheme: system });
-	});
-
-	const handleSystemChangeEvent = useEffectEvent((next: "light" | "dark") => {
-		setStoreSystemTheme(next);
-		const current = getSnapshot().theme;
-		if (current === "system" || current === undefined || followSystem) {
-			const followsVariant =
-				followSystem && !!systemThemeMap && !isDirectSystemMap(systemThemeMap);
-			if (followSystem && !followsVariant) setStoreTheme("system");
-			const resolved =
-				resolveSelection(
-					followsVariant
-						? (current ?? resolvedDefault)
-						: followSystem
-							? "system"
-							: (current ?? "system"),
-					next,
-					systemThemeMap as SystemThemeMap<string> | undefined,
-				) ?? next;
-			applyToDomEvent(resolved);
-			onThemeChangeEvent(next as Themes);
-		}
-	});
-
-	// oxlint-disable-next-line react-hooks/exhaustive-deps -- applyToDomEvent is an effect event.
-	const setTheme = useCallback(
-		(
-			next:
-				| Themes
-				| "system"
-				| ((current: Themes | "system" | undefined) => Themes | "system"),
-		) => {
-			if (validForcedTheme) return;
-
-			const current = getSnapshot().theme as Themes | "system" | undefined;
-			const newTheme = typeof next === "function" ? next(current) : next;
-			if (!isThemeSelection(newTheme, stableThemes, enableSystem)) return;
-			const resolved = resolveSelection(
-				newTheme,
-				getSnapshot().systemTheme,
-				systemThemeMap as SystemThemeMap<string> | undefined,
-			);
-
-			setStoreTheme(newTheme);
-			// oxlint-disable-next-line react-hooks/rules-of-hooks -- shared apply path; setTheme stays a public callback.
-			if (resolved) applyToDomEvent(resolved);
-			onThemeChange?.(newTheme as Themes);
-			writeStoredTheme(storage, storageKey, newTheme, cookieOptions, onStorageError);
-			if (enableSameDocumentSync && storage !== "none")
-				publishThemeChannel(channel, newTheme);
-		},
-		[
-			validForcedTheme,
-			stableThemes,
-			enableSystem,
-			systemThemeMap,
-			storage,
-			storageKey,
-			cookieOptions,
-			onStorageError,
-			channel,
-			enableSameDocumentSync,
-			getSnapshot,
-			setStoreTheme,
-			onThemeChange,
-		],
-	);
-
-	// oxlint-disable-next-line react-hooks/exhaustive-deps -- effect events are intentionally non-reactive.
-	useEffect(() => {
-		initializeEvent();
-		const domWindow = getDomWindow();
-		if (!domWindow) return;
-		return subscribeHistoryReapply(domWindow, () => {
-			const last = lastAppliedRef.current;
-			if (last) applyToDomEvent(last.resolved);
-		});
-	}, []);
-
-	// setTheme / system / storage already write the DOM. Re-apply only when
-	// resolvedTheme or DOM config changed from outside those paths.
-	// oxlint-disable-next-line react-hooks/exhaustive-deps -- effect events are intentionally non-reactive.
-	useEffect(() => {
-		if (!resolvedTheme) return;
-		const last = lastAppliedRef.current;
-		if (
-			last &&
-			last.resolved === resolvedTheme &&
+		}),
+		sameLast: (last, resolved, config) =>
+			last.resolved === resolved &&
 			last.attribute === attribute &&
-			last.themes === stableThemes &&
-			last.valueMap === stableValueMap &&
+			last.themes === config.themes &&
+			last.valueMap === config.valueMap &&
 			last.target === target &&
 			last.disableTransitionOnChange === disableTransitionOnChange &&
 			last.enableColorScheme === enableColorScheme &&
-			last.themeColor === stableThemeColor &&
-			last.themeRoot === themeRoot
-		) {
-			return;
-		}
-		applyToDomEvent(resolvedTheme);
-	}, [
-		resolvedTheme,
-		attribute,
-		stableThemes,
-		stableValueMap,
-		target,
-		disableTransitionOnChange,
-		enableColorScheme,
-		stableThemeColor,
-		themeRoot,
-	]);
+			last.themeColor === config.themeColor &&
+			last.themeRoot === themeRoot,
+		applyLast: (last) => {
+			appliedThemeRef.current = applyExtendedThemeToDom({
+				...last,
+				previous: appliedThemeRef.current,
+			});
+		},
+		afterSetTheme: (newTheme) => {
+			if (enableSameDocumentSync && storage !== "none") {
+				publishThemeChannel(channel, newTheme);
+			}
+		},
+	});
 
-	// oxlint-disable-next-line react-hooks/exhaustive-deps -- effect events are intentionally non-reactive.
-	useEffect(() => {
-		const domWindow = getDomWindow();
-		if (!enableSystem || !domWindow || typeof domWindow.matchMedia !== "function") return;
-		const mq = domWindow.matchMedia("(prefers-color-scheme: dark)");
-		setStoreSystemTheme(mq.matches ? "dark" : "light");
-		const handler = (event: MediaQueryListEvent) => {
-			handleSystemChangeEvent(event.matches ? "dark" : "light");
-		};
-		mq.addEventListener?.("change", handler);
-		return () => mq.removeEventListener?.("change", handler);
-	}, [enableSystem, setStoreSystemTheme]);
-
-	// oxlint-disable-next-line react-hooks/exhaustive-deps -- effect events are intentionally non-reactive.
-	useEffect(() => {
-		const domWindow = getDomWindow();
-		if (!domWindow) return;
-		if (
-			followSystem ||
-			storage === "none" ||
-			storage === "sessionStorage" ||
-			storage === "cookie"
-		)
-			return;
-
-		const handler = (event: StorageEvent) => {
-			if (event.storageArea !== localStorage || event.key !== storageKey) return;
-			const newTheme = event.newValue ?? resolvedDefault;
-			if (!isThemeSelection(newTheme, themes, enableSystem)) return;
-			const resolved = resolveSelection(
-				newTheme,
-				getSnapshot().systemTheme,
-				systemThemeMap as SystemThemeMap<string> | undefined,
-			);
-			setStoreTheme(newTheme);
-			if (!validForcedTheme && resolved) applyToDomEvent(resolved);
-		};
-		domWindow.addEventListener("storage", handler);
-		return () => domWindow.removeEventListener("storage", handler);
-	}, [
-		followSystem,
-		storage,
-		storageKey,
-		resolvedDefault,
-		themes,
-		enableSystem,
-		systemThemeMap,
-		validForcedTheme,
-		getSnapshot,
-		setStoreTheme,
-	]);
+	const applyChannelThemeEvent = useEffectEvent((newTheme: string) => {
+		if (!isThemeSelection(newTheme, themes, enableSystem)) return;
+		setStoreTheme(newTheme);
+		const resolved = resolveSelection(
+			newTheme,
+			getSnapshot().systemTheme,
+			systemThemeMap as SystemThemeMap<string> | undefined,
+		);
+		if (!validForcedTheme && resolved) applyResolved(resolved);
+	});
 
 	// oxlint-disable-next-line react-hooks/exhaustive-deps -- effect events are intentionally non-reactive.
 	useEffect(() => {
 		if (!enableSameDocumentSync || storage === "none") return;
-		return subscribeThemeChannel(channel, (newTheme) => {
-			if (!isThemeSelection(newTheme, themes, enableSystem)) return;
-			setStoreTheme(newTheme);
-			const resolved = resolveSelection(
-				newTheme,
-				getSnapshot().systemTheme,
-				systemThemeMap as SystemThemeMap<string> | undefined,
-			);
-			if (!validForcedTheme && resolved) applyToDomEvent(resolved);
-		});
-	}, [
-		enableSameDocumentSync,
-		storage,
-		channel,
-		themes,
-		enableSystem,
-		systemThemeMap,
-		validForcedTheme,
-		getSnapshot,
-		setStoreTheme,
-	]);
+		return subscribeThemeChannel(channel, applyChannelThemeEvent);
+	}, [enableSameDocumentSync, storage, channel]);
 
 	const contextValue = useMemo(
 		(): ThemeContextValue<string> => ({

--- a/packages/themes/src/providers/extended-client-provider.tsx
+++ b/packages/themes/src/providers/extended-client-provider.tsx
@@ -8,6 +8,12 @@ import {
 	useRef,
 	useSyncExternalStore,
 } from "react";
+import {
+	holdIfEqual,
+	sameStringList,
+	sameStringRecord,
+	sameThemeColor,
+} from "../core/config-equal.js";
 import { ThemeContext } from "../core/context.js";
 import {
 	type AppliedThemeState,
@@ -95,6 +101,15 @@ export function ExtendedClientThemeProvider<Themes extends string = DefaultTheme
 	const store = storeRef.current;
 	const appliedThemeRef = useRef<AppliedThemeState | undefined>(undefined);
 	const lastAppliedRef = useRef<LastAppliedTheme | null>(null);
+	const themesRef = useRef(themes);
+	themesRef.current = holdIfEqual(themesRef.current, themes, sameStringList);
+	const stableThemes = themesRef.current;
+	const valueMapRef = useRef(valueMap);
+	valueMapRef.current = holdIfEqual(valueMapRef.current, valueMap, sameStringRecord);
+	const stableValueMap = valueMapRef.current;
+	const themeColorRef = useRef(themeColor);
+	themeColorRef.current = holdIfEqual(themeColorRef.current, themeColor, sameThemeColor);
+	const stableThemeColor = themeColorRef.current;
 	const {
 		getSnapshot,
 		setState: setStoreState,
@@ -108,7 +123,8 @@ export function ExtendedClientThemeProvider<Themes extends string = DefaultTheme
 		store.getServerSnapshot,
 	);
 
-	const validForcedTheme = forcedTheme && themes.includes(forcedTheme) ? forcedTheme : undefined;
+	const validForcedTheme =
+		forcedTheme && stableThemes.includes(forcedTheme) ? forcedTheme : undefined;
 	const selectedTheme = validForcedTheme ?? theme;
 	const resolvedTheme = selectedTheme
 		? (resolveSelection(
@@ -127,12 +143,12 @@ export function ExtendedClientThemeProvider<Themes extends string = DefaultTheme
 		const last: LastAppliedTheme = {
 			resolved,
 			attribute,
-			themes,
-			valueMap,
+			themes: stableThemes,
+			valueMap: stableValueMap,
 			target,
 			disableTransitionOnChange,
 			enableColorScheme,
-			themeColor,
+			themeColor: stableThemeColor,
 			themeRoot,
 		};
 		appliedThemeRef.current = applyExtendedThemeToDom({
@@ -209,7 +225,7 @@ export function ExtendedClientThemeProvider<Themes extends string = DefaultTheme
 
 			const current = getSnapshot().theme as Themes | "system" | undefined;
 			const newTheme = typeof next === "function" ? next(current) : next;
-			if (!isThemeSelection(newTheme, themes, enableSystem)) return;
+			if (!isThemeSelection(newTheme, stableThemes, enableSystem)) return;
 			const resolved = resolveSelection(
 				newTheme,
 				getSnapshot().systemTheme,
@@ -226,7 +242,7 @@ export function ExtendedClientThemeProvider<Themes extends string = DefaultTheme
 		},
 		[
 			validForcedTheme,
-			themes,
+			stableThemes,
 			enableSystem,
 			systemThemeMap,
 			storage,
@@ -262,11 +278,12 @@ export function ExtendedClientThemeProvider<Themes extends string = DefaultTheme
 			last &&
 			last.resolved === resolvedTheme &&
 			last.attribute === attribute &&
-			last.themes === themes &&
-			last.valueMap === valueMap &&
+			last.themes === stableThemes &&
+			last.valueMap === stableValueMap &&
 			last.target === target &&
+			last.disableTransitionOnChange === disableTransitionOnChange &&
 			last.enableColorScheme === enableColorScheme &&
-			last.themeColor === themeColor &&
+			last.themeColor === stableThemeColor &&
 			last.themeRoot === themeRoot
 		) {
 			return;
@@ -275,12 +292,12 @@ export function ExtendedClientThemeProvider<Themes extends string = DefaultTheme
 	}, [
 		resolvedTheme,
 		attribute,
-		themes,
-		valueMap,
+		stableThemes,
+		stableValueMap,
 		target,
 		disableTransitionOnChange,
 		enableColorScheme,
-		themeColor,
+		stableThemeColor,
 		themeRoot,
 	]);
 
@@ -367,10 +384,10 @@ export function ExtendedClientThemeProvider<Themes extends string = DefaultTheme
 			resolvedTheme,
 			systemTheme,
 			forcedTheme: validForcedTheme,
-			themes,
+			themes: stableThemes,
 			setTheme: setTheme as ThemeContextValue<string>["setTheme"],
 		}),
-		[validForcedTheme, theme, resolvedTheme, systemTheme, themes, setTheme],
+		[validForcedTheme, theme, resolvedTheme, systemTheme, stableThemes, setTheme],
 	);
 
 	return <ThemeContext.Provider value={contextValue}>{children}</ThemeContext.Provider>;


### PR DESCRIPTION
## Summary
- Default and extended client providers duplicated store init, history reapply, and storage/system effects.
- Extract that runtime into `useClientThemeRuntime` and a shared `theme-storage` helper.
- Keep `client-dom` / `extended-client-dom` apply paths and the two bootstraps split. Extended still owns `systemThemeMap`, `enableSameDocumentSync`, and `themeRoot`.
- Stacked on #104. Raises next-provider budgets for the honest abstraction cost rather than shrinking or obfuscating the share. Default `client-provider` gzip stays under its 3900-byte cap.

## Test plan
- [x] `bun test` from `packages/themes`
- [x] `bun run size:compare` from `packages/themes`
- [ ] CI library + size jobs